### PR TITLE
Revert "Add check for PSK_CAP to 1.0"

### DIFF
--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -28,9 +28,6 @@ Assertion 2.1.3:
 
 Assertion 2.1.4:
     Flags.MEAS_CAP != 3
-    
-Assertion 2.1.5:
-    Flags.PSK_CAP != 3
 
 ### Case 2.2
 


### PR DESCRIPTION
This reverts commit 986630ec5c93e85254578cc0fa2c599fb78ccea1.

The PSK should not be in 1.0.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>