### PR TITLE
Remove dead code in 'spdm_responder_conformance_test_lib'

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -653,11 +653,9 @@ void spdm_test_case_certificate_invalid_request (void *test_context)
         } else if (index == SPDM_MAX_SLOT_COUNT * 2) {
             common_test_record_test_message ("test invalid offset - 0x%04x\n", 0xFFFF);
             spdm_request_new.offset = 0xFFFF;
-        } else if (index == SPDM_MAX_SLOT_COUNT * 2 + 1) {
+        } else {
             common_test_record_test_message ("test invalid length - 0x%04x\n", 0);
             spdm_request_new.length = 0;
-        } else {
-            break;
         }
 
         spdm_response = (void *)message;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -914,12 +914,10 @@ void spdm_test_case_challenge_auth_invalid_request (void *test_context)
                                              1);
             spdm_request_new.header.param2 = SPDM_CHALLENGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH +
                                              1;
-        } else if (index == SPDM_MAX_SLOT_COUNT * 2 + 1) {
+        } else {
             common_test_record_test_message ("test invalid meas_hash_type - 0x%02x\n",
                                              SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH - 1);
             spdm_request_new.header.param2 = SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH - 1;
-        } else {
-            break;
         }
 
         spdm_response = (void *)message;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -1575,17 +1575,13 @@ void spdm_test_case_measurements_invalid_request (void *test_context)
         libspdm_copy_mem (&spdm_request_new, sizeof(spdm_request_new), &spdm_request,
                           sizeof(spdm_request));
 
-        if (index < SPDM_MAX_SLOT_COUNT * 2) {
-            slot_id = (uint8_t)index;
-            if ((slot_id < SPDM_MAX_SLOT_COUNT) &&
-                ((test_buffer->slot_mask & (0x1 << slot_id)) != 0)) {
-                continue;
-            }
-            common_test_record_test_message ("test invalid slot - 0x%02x\n", slot_id);
-            spdm_request_new.slot_id_param = slot_id;
-        } else {
-            break;
+        slot_id = (uint8_t)index;
+        if ((slot_id < SPDM_MAX_SLOT_COUNT) &&
+            ((test_buffer->slot_mask & (0x1 << slot_id)) != 0)) {
+            continue;
         }
+        common_test_record_test_message ("test invalid slot - 0x%02x\n", slot_id);
+        spdm_request_new.slot_id_param = slot_id;
 
         spdm_response = (void *)message;
         spdm_response_size = sizeof(message);

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -1266,12 +1266,10 @@ void spdm_test_case_key_exchange_rsp_invalid_request (void *test_context)
                                              1);
             spdm_request_new.header.param1 =
                 SPDM_KEY_EXCHANGE_REQUEST_TCB_COMPONENT_MEASUREMENT_HASH + 1;
-        } else if (index == SPDM_MAX_SLOT_COUNT * 2 + 1) {
+        } else {
             common_test_record_test_message ("test invalid meas_hash_type - 0x%02x\n",
                                              SPDM_KEY_EXCHANGE_REQUEST_ALL_MEASUREMENTS_HASH - 1);
             spdm_request_new.header.param1 = SPDM_KEY_EXCHANGE_REQUEST_ALL_MEASUREMENTS_HASH - 1;
-        } else {
-            break;
         }
 
         spdm_response = (void *)message;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -1061,11 +1061,9 @@ void spdm_test_case_finish_rsp_invalid_request (void *test_context)
             }
             common_test_record_test_message ("test invalid slot - 0x%02x\n", slot_id);
             spdm_request_new.header.param2 = slot_id;
-        } else if (index == SPDM_MAX_SLOT_COUNT * 2) {
+        } else {
             common_test_record_test_message ("test invalid size - 0x%x\n", spdm_request_size);
             spdm_request_size = sizeof(spdm_finish_request_t);
-        } else {
-            break;
         }
 
         spdm_response = (void *)message;


### PR DESCRIPTION
Removed the unreached `else` path
Fix: #32
Signed-off-by: yaohuixguo <yaohuix.guo@intel.com>