### PR TITLE
Fix test_group_version error for 1.2

### DIFF
--- a/doc/1.Version.md
+++ b/doc/1.Version.md
@@ -54,7 +54,7 @@ Assertion 1.2.3:
     SpdmMessage.SPDMVersion == 0x10
 
 Assertion 1.2.4:
-    SpdmMessage.Param1 == InvalidRequest.
+    (SpdmMessage.Param1 == InvalidRequest) OR (SpdmMessage.Param1 == VersionMismatch)
 
 Assertion 1.2.5:
     SpdmMessage.Param2 == 0.

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_1_version.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_1_version.c
@@ -178,7 +178,8 @@ void spdm_test_case_version_invalid_request (void *test_context)
         return;
     }
 
-    if (spdm_response->header.param1 == SPDM_ERROR_CODE_INVALID_REQUEST) {
+    if ((spdm_response->header.param1 == SPDM_ERROR_CODE_INVALID_REQUEST) ||
+        (spdm_response->header.param1 == SPDM_ERROR_CODE_VERSION_MISMATCH)) {
         test_result = COMMON_TEST_RESULT_PASS;
     } else {
         test_result = COMMON_TEST_RESULT_FAIL;


### PR DESCRIPTION
Fix: #43 

And  test_group_version error has been fixed by this patch.

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>