### PR TITLE
Clean up context for every case

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test.h
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test.h
@@ -34,6 +34,30 @@ typedef struct {
  **/
 uint32_t spdm_test_get_one_bit (uint32_t data, uint32_t mask);
 
+/**
+ * Initialize an SPDM context for SPDM-Responder-Validator, as well as secured message contexts.
+ * The secured message contexts are appended to the context structure.
+ *
+ * The total size in bytes of the spdm_context and all secured message
+ * contexts can be returned by libspdm_get_context_size().
+ *
+ * @param  spdm_context         A pointer to the SPDM context.
+ *
+ * @retval RETURN_SUCCESS       context is initialized.
+ * @retval RETURN_DEVICE_ERROR  context initialization failed.
+ */
+libspdm_return_t libspdm_init_context_for_responder_validator(void *context);
+
+/**
+ * Free the memory of contexts within the SPDM context.
+ * These are typically contexts whose memory has been allocated by the cryptography library.
+ * This function does not free the SPDM context itself.
+ *
+ * @param[in]  spdm_context         A pointer to the SPDM context.
+ *
+ */
+void libspdm_deinit_context_for_responder_validator(void *test_context);
+
 extern common_test_case_t m_spdm_test_group_version[];
 extern common_test_case_t m_spdm_test_group_capabilities[];
 extern common_test_case_t m_spdm_test_group_algorithms[];

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -32,6 +32,7 @@ bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -594,18 +595,26 @@ void spdm_test_case_heartbeat_ack_session_required (void *test_context)
 common_test_case_t m_spdm_test_group_heartbeat_ack[] = {
     {SPDM_RESPONDER_TEST_CASE_HEARTBEAT_ACK_SUCCESS_11_IN_DHE_SESSION,
      "spdm_test_case_heartbeat_ack_success_11_dhe", spdm_test_case_heartbeat_ack_success_11_dhe,
-     spdm_test_case_heartbeat_ack_setup_version_any},
+     spdm_test_case_heartbeat_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_HEARTBEAT_ACK_VERSION_MISMATCH_IN_DHE_SESSION,
      "spdm_test_case_heartbeat_ack_version_mismatch",
      spdm_test_case_heartbeat_ack_version_mismatch,
-     spdm_test_case_heartbeat_ack_setup_version_any},
+     spdm_test_case_heartbeat_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_HEARTBEAT_ACK_UNEXPECTED_REQUEST_IN_DHE_SESSION_HS,
      "spdm_test_case_heartbeat_ack_unexpected_request",
      spdm_test_case_heartbeat_ack_unexpected_request,
-     spdm_test_case_heartbeat_ack_setup_version_any_session_cap},
+     spdm_test_case_heartbeat_ack_setup_version_any_session_cap,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_HEARTBEAT_ACK_SESSION_REQUIRED,
      "spdm_test_case_heartbeat_ack_session_required",
      spdm_test_case_heartbeat_ack_session_required,
-     spdm_test_case_heartbeat_ack_setup_version_12},
+     spdm_test_case_heartbeat_ack_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -31,6 +31,7 @@ bool spdm_test_case_key_update_ack_setup_session (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -1055,22 +1056,32 @@ common_test_case_t m_spdm_test_group_key_update_ack[] = {
     {SPDM_RESPONDER_TEST_CASE_KEY_UPDATE_ACK_SUCCESS_11_IN_DHE_SESSION,
      "spdm_test_case_key_update_ack_success_11_dhe",
      spdm_test_case_key_update_ack_success_11_dhe,
-     spdm_test_case_key_update_ack_setup_version_any},
+     spdm_test_case_key_update_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_UPDATE_ACK_VERSION_MISMATCH_IN_DHE_SESSION,
      "spdm_test_case_key_update_ack_version_mismatch",
      spdm_test_case_key_update_ack_version_mismatch,
-     spdm_test_case_key_update_ack_setup_version_any},
+     spdm_test_case_key_update_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_UPDATE_ACK_INVALID_REQUEST_IN_DHE_SESSION,
      "spdm_test_case_key_update_ack_invalid_request",
      spdm_test_case_key_update_ack_invalid_request,
-     spdm_test_case_key_update_ack_setup_version_any},
+     spdm_test_case_key_update_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_UPDATE_ACK_UNEXPECTED_REQUEST_IN_DHE_SESSION_HS,
      "spdm_test_case_key_update_ack_unexpected_request",
      spdm_test_case_key_update_ack_unexpected_request,
-     spdm_test_case_key_update_ack_setup_version_any_session_cap},
+     spdm_test_case_key_update_ack_setup_version_any_session_cap,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_UPDATE_ACK_SESSION_REQUIRED,
      "spdm_test_case_key_update_ack_session_required",
      spdm_test_case_key_update_ack_session_required,
-     spdm_test_case_key_update_ack_setup_version_12},
+     spdm_test_case_key_update_ack_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -32,6 +32,7 @@ bool spdm_test_case_end_session_ack_setup_session (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -594,18 +595,26 @@ common_test_case_t m_spdm_test_group_end_session_ack[] = {
     {SPDM_RESPONDER_TEST_CASE_END_SESSION_ACK_SUCCESS_11_IN_DHE_SESSION,
      "spdm_test_case_end_session_ack_success_11_dhe",
      spdm_test_case_end_session_ack_success_11_dhe,
-     spdm_test_case_end_session_ack_setup_version_any},
+     spdm_test_case_end_session_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_END_SESSION_ACK_VERSION_MISMATCH_IN_DHE_SESSION,
      "spdm_test_case_end_session_ack_version_mismatch",
      spdm_test_case_end_session_ack_version_mismatch,
-     spdm_test_case_end_session_ack_setup_version_any},
+     spdm_test_case_end_session_ack_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_END_SESSION_ACK_UNEXPECTED_REQUEST_IN_DHE_SESSION_HS,
      "spdm_test_case_end_session_ack_unexpected_request",
      spdm_test_case_end_session_ack_unexpected_request,
-     spdm_test_case_end_session_ack_setup_version_any_session_cap},
+     spdm_test_case_end_session_ack_setup_version_any_session_cap,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_END_SESSION_ACK_SESSION_REQUIRED,
      "spdm_test_case_end_session_ack_session_required",
      spdm_test_case_end_session_ack_session_required,
-     spdm_test_case_end_session_ack_setup_version_12},
+     spdm_test_case_end_session_ack_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -25,6 +25,7 @@ bool spdm_test_case_capabilities_setup_version (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     libspdm_zero_mem(&parameter, sizeof(parameter));
     parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
@@ -56,6 +57,7 @@ bool spdm_test_case_capabilities_setup_version_all (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     test_buffer = (void *)spdm_test_context->test_scratch_buffer;
     LIBSPDM_ASSERT(sizeof(spdm_test_context->test_scratch_buffer) >=
@@ -1146,21 +1148,32 @@ void spdm_test_case_capabilities_unexpected_non_identical (void *test_context)
 
 common_test_case_t m_spdm_test_group_capabilities[] = {
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_10, "spdm_test_case_capabilities_success_10",
-     spdm_test_case_capabilities_success_10, spdm_test_case_capabilities_setup_version_10},
+     spdm_test_case_capabilities_success_10, spdm_test_case_capabilities_setup_version_10,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_VERSION_MISMATCH,
      "spdm_test_case_capabilities_version_mismatch",
      spdm_test_case_capabilities_version_mismatch,
-     spdm_test_case_capabilities_setup_version_all},
+     spdm_test_case_capabilities_setup_version_all,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_11, "spdm_test_case_capabilities_success_11",
-     spdm_test_case_capabilities_success_11, spdm_test_case_capabilities_setup_version_11},
+     spdm_test_case_capabilities_success_11, spdm_test_case_capabilities_setup_version_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_INVALID_REQUEST,
      "spdm_test_case_capabilities_invalid_request", spdm_test_case_capabilities_invalid_request,
-     spdm_test_case_capabilities_setup_version_all},
+     spdm_test_case_capabilities_setup_version_all, libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_12, "spdm_test_case_capabilities_success_12",
-     spdm_test_case_capabilities_success_12, spdm_test_case_capabilities_setup_version_12},
+     spdm_test_case_capabilities_success_12, spdm_test_case_capabilities_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_UNEXPECTED_REQUEST_NON_IDENTICAL,
      "spdm_test_case_capabilities_unexpected_non_identical",
      spdm_test_case_capabilities_unexpected_non_identical,
-     spdm_test_case_capabilities_setup_version_all},
+     spdm_test_case_capabilities_setup_version_all,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
@@ -43,6 +43,7 @@ bool spdm_test_case_algorithms_setup_version_capabilities (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -128,6 +129,7 @@ bool spdm_test_case_algorithms_setup_version_only (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     test_buffer = (void *)spdm_test_context->test_scratch_buffer;
     LIBSPDM_ASSERT(sizeof(spdm_test_context->test_scratch_buffer) >=
@@ -2176,23 +2178,34 @@ void spdm_test_case_algorithms_unexpected_non_identical (void *test_context)
 
 common_test_case_t m_spdm_test_group_algorithms[] = {
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_SUCCESS_10, "spdm_test_case_algorithms_success_10",
-     spdm_test_case_algorithms_success_10, spdm_test_case_algorithms_setup_version_10},
+     spdm_test_case_algorithms_success_10, spdm_test_case_algorithms_setup_version_10,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_VERSION_MISMATCH,
      "spdm_test_case_algorithms_version_mismatch", spdm_test_case_algorithms_version_mismatch,
-     spdm_test_case_algorithms_setup_version_any},
+     spdm_test_case_algorithms_setup_version_any, libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_UNEXPECTED_REQUEST,
      "spdm_test_case_algorithms_unexpected_request",
-     spdm_test_case_algorithms_unexpected_request, spdm_test_case_algorithms_setup_version_only},
+     spdm_test_case_algorithms_unexpected_request, spdm_test_case_algorithms_setup_version_only,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_INVALID_REQUEST,
      "spdm_test_case_algorithms_invalid_request", spdm_test_case_algorithms_invalid_request,
-     spdm_test_case_algorithms_setup_version_any},
+     spdm_test_case_algorithms_setup_version_any, libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_SUCCESS_11, "spdm_test_case_algorithms_success_11",
-     spdm_test_case_algorithms_success_11, spdm_test_case_algorithms_setup_version_11},
+     spdm_test_case_algorithms_success_11, spdm_test_case_algorithms_setup_version_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_SUCCESS_12, "spdm_test_case_algorithms_success_12",
-     spdm_test_case_algorithms_success_12, spdm_test_case_algorithms_setup_version_12},
+     spdm_test_case_algorithms_success_12, spdm_test_case_algorithms_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_ALGORITHMS_UNEXPECTED_REQUEST_NON_IDENTICAL,
      "spdm_test_case_algorithms_unexpected_non_identical",
      spdm_test_case_algorithms_unexpected_non_identical,
-     spdm_test_case_algorithms_setup_version_any},
+     spdm_test_case_algorithms_setup_version_any, libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
@@ -30,6 +30,7 @@ bool spdm_test_case_digests_setup_vca (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -166,6 +167,7 @@ bool spdm_test_case_digests_setup_version_capabilities (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -515,11 +517,17 @@ void spdm_test_case_digests_unexpected_request (void *test_context)
 
 common_test_case_t m_spdm_test_group_digests[] = {
     {SPDM_RESPONDER_TEST_CASE_DIGESTS_SUCCESS_10, "spdm_test_case_digests_success_10",
-     spdm_test_case_digests_success_10, spdm_test_case_digests_setup_version_any},
+     spdm_test_case_digests_success_10, spdm_test_case_digests_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_DIGESTS_VERSION_MISMATCH, "spdm_test_case_digests_version_mismatch",
-     spdm_test_case_digests_version_mismatch, spdm_test_case_digests_setup_version_any},
+     spdm_test_case_digests_version_mismatch, spdm_test_case_digests_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_DIGESTS_UNEXPECTED_REQUEST,
      "spdm_test_case_digests_unexpected_request", spdm_test_case_digests_unexpected_request,
-     spdm_test_case_digests_setup_version_capabilities},
+     spdm_test_case_digests_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -34,6 +34,7 @@ bool spdm_test_case_certificate_setup_vca_digest (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -187,6 +188,7 @@ bool spdm_test_case_certificate_setup_version_capabilities (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -732,16 +734,23 @@ void spdm_test_case_certificate_invalid_request (void *test_context)
 
 common_test_case_t m_spdm_test_group_certificate[] = {
     {SPDM_RESPONDER_TEST_CASE_CERTIFICATE_SUCCESS_10, "spdm_test_case_certificate_success_10",
-     spdm_test_case_certificate_success_10, spdm_test_case_certificate_setup_version_any},
+     spdm_test_case_certificate_success_10, spdm_test_case_certificate_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CERTIFICATE_VERSION_MISMATCH,
      "spdm_test_case_certificate_version_mismatch", spdm_test_case_certificate_version_mismatch,
-     spdm_test_case_certificate_setup_version_any},
+     spdm_test_case_certificate_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CERTIFICATE_UNEXPECTED_REQUEST,
      "spdm_test_case_certificate_unexpected_request",
      spdm_test_case_certificate_unexpected_request,
-     spdm_test_case_certificate_setup_version_capabilities},
+     spdm_test_case_certificate_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CERTIFICATE_INVALID_REQUEST,
      "spdm_test_case_certificate_invalid_request", spdm_test_case_certificate_invalid_request,
-     spdm_test_case_certificate_setup_version_any},
+     spdm_test_case_certificate_setup_version_any, libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -42,6 +42,7 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version_count != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -218,6 +219,7 @@ bool spdm_test_case_challenge_auth_setup_version_capabilities (void *test_contex
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -999,58 +1001,86 @@ common_test_case_t m_spdm_test_group_challenge_auth[] = {
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_10_A1B1C1,
      "spdm_test_case_challenge_auth_success_10_a1b1c1",
      spdm_test_case_challenge_auth_success_10_a1b1c1,
-     spdm_test_case_challenge_auth_setup_version_10_11},
+     spdm_test_case_challenge_auth_setup_version_10_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_10_A1B2C1,
      "spdm_test_case_challenge_auth_success_10_a1b2c1",
      spdm_test_case_challenge_auth_success_10_a1b2c1,
-     spdm_test_case_challenge_auth_setup_version_10_11},
+     spdm_test_case_challenge_auth_setup_version_10_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_10_A1B3C1,
      "spdm_test_case_challenge_auth_success_10_a1b3c1",
      spdm_test_case_challenge_auth_success_10_a1b3c1,
-     spdm_test_case_challenge_auth_setup_version_10_11},
+     spdm_test_case_challenge_auth_setup_version_10_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_VERSION_MISMATCH,
      "spdm_test_case_challenge_auth_version_mismatch",
      spdm_test_case_challenge_auth_version_mismatch,
-     spdm_test_case_challenge_auth_setup_version_any},
+     spdm_test_case_challenge_auth_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_UNEXPECTED_REQUEST,
      "spdm_test_case_challenge_auth_unexpected_request",
      spdm_test_case_challenge_auth_unexpected_request,
-     spdm_test_case_challenge_auth_setup_version_capabilities},
+     spdm_test_case_challenge_auth_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_INVALID_REQUEST,
      "spdm_test_case_challenge_auth_invalid_request",
      spdm_test_case_challenge_auth_invalid_request,
-     spdm_test_case_challenge_auth_setup_version_any},
+     spdm_test_case_challenge_auth_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B1C1,
      "spdm_test_case_challenge_auth_success_12_a1b1c1",
      spdm_test_case_challenge_auth_success_12_a1b1c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B2C1,
      "spdm_test_case_challenge_auth_success_12_a1b2c1",
      spdm_test_case_challenge_auth_success_12_a1b2c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B3C1,
      "spdm_test_case_challenge_auth_success_12_a1b3c1",
      spdm_test_case_challenge_auth_success_12_a1b3c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B4C1,
      "spdm_test_case_challenge_auth_success_12_a1b4c1",
      spdm_test_case_challenge_auth_success_12_a1b4c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B1C1,
      "spdm_test_case_challenge_auth_success_12_a2b1c1",
      spdm_test_case_challenge_auth_success_12_a2b1c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B2C1,
      "spdm_test_case_challenge_auth_success_12_a2b2c1",
      spdm_test_case_challenge_auth_success_12_a2b2c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B3C1,
      "spdm_test_case_challenge_auth_success_12_a2b3c1",
      spdm_test_case_challenge_auth_success_12_a2b3c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B4C1,
      "spdm_test_case_challenge_auth_success_12_a2b4c1",
      spdm_test_case_challenge_auth_success_12_a2b4c1,
-     spdm_test_case_challenge_auth_setup_version_12},
+     spdm_test_case_challenge_auth_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -40,6 +40,7 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version_count != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -301,6 +302,7 @@ bool spdm_test_case_measurements_setup_version_capabilities (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -1784,33 +1786,51 @@ void spdm_test_case_measurements_unexpected_request_in_session (void *test_conte
 
 common_test_case_t m_spdm_test_group_measurements[] = {
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_SUCCESS_10, "spdm_test_case_measurements_success_10",
-     spdm_test_case_measurements_success_10, spdm_test_case_measurements_setup_version_10},
+     spdm_test_case_measurements_success_10, spdm_test_case_measurements_setup_version_10,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_VERSION_MISMATCH,
      "spdm_test_case_measurements_version_mismatch",
      spdm_test_case_measurements_version_mismatch,
-     spdm_test_case_measurements_setup_version_any},
+     spdm_test_case_measurements_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_UNEXPECTED_REQUEST,
      "spdm_test_case_measurements_unexpected_request",
      spdm_test_case_measurements_unexpected_request,
-     spdm_test_case_measurements_setup_version_capabilities},
+     spdm_test_case_measurements_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_INVALID_REQUEST,
      "spdm_test_case_measurements_invalid_request", spdm_test_case_measurements_invalid_request,
-     spdm_test_case_measurements_setup_version_any},
+     spdm_test_case_measurements_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_SUCCESS_11, "spdm_test_case_measurements_success_11",
-     spdm_test_case_measurements_success_11, spdm_test_case_measurements_setup_version_11},
+     spdm_test_case_measurements_success_11, spdm_test_case_measurements_setup_version_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_SUCCESS_11_IN_DHE_SESSION,
      "spdm_test_case_measurements_success_11_session",
      spdm_test_case_measurements_success_11_session,
-     spdm_test_case_measurements_setup_version_11_session},
+     spdm_test_case_measurements_setup_version_11_session,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_UNEXPECTED_REQUEST_IN_DHE_SESSION_HS,
      "spdm_test_case_measurements_unexpected_request_in_session",
      spdm_test_case_measurements_unexpected_request_in_session,
-     spdm_test_case_measurements_setup_version_any_session_cap},
+     spdm_test_case_measurements_setup_version_any_session_cap,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_SUCCESS_12, "spdm_test_case_measurements_success_12",
-     spdm_test_case_measurements_success_12, spdm_test_case_measurements_setup_version_12},
+     spdm_test_case_measurements_success_12, spdm_test_case_measurements_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_MEASUREMENTS_SUCCESS_12_IN_DHE_SESSION,
      "spdm_test_case_measurements_success_12_session",
      spdm_test_case_measurements_success_12_session,
-     spdm_test_case_measurements_setup_version_12_session},
+     spdm_test_case_measurements_setup_version_12_session,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -57,6 +57,7 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version_count != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -275,6 +276,7 @@ bool spdm_test_case_key_exchange_rsp_setup_version_capabilities (void *test_cont
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -1350,33 +1352,49 @@ void spdm_test_case_key_exchange_rsp_invalid_request (void *test_context)
 common_test_case_t m_spdm_test_group_key_exchange_rsp[] = {
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_SUCCESS_11,
      "spdm_test_case_key_exchange_rsp_success_11", spdm_test_case_key_exchange_rsp_success_11,
-     spdm_test_case_key_exchange_rsp_setup_version_11},
+     spdm_test_case_key_exchange_rsp_setup_version_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_SUCCESS_11_HS_CLEAR,
      "spdm_test_case_key_exchange_rsp_success_11_hs_clear",
      spdm_test_case_key_exchange_rsp_success_11_hs_clear,
-     spdm_test_case_key_exchange_rsp_setup_version_11_hs_clear},
+     spdm_test_case_key_exchange_rsp_setup_version_11_hs_clear,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_VERSION_MISMATCH,
      "spdm_test_case_key_exchange_rsp_version_mismatch",
      spdm_test_case_key_exchange_rsp_version_mismatch,
-     spdm_test_case_key_exchange_rsp_setup_version_any},
+     spdm_test_case_key_exchange_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_UNEXPECTED_REQUEST,
      "spdm_test_case_key_exchange_rsp_unexpected_request",
      spdm_test_case_key_exchange_rsp_unexpected_request,
-     spdm_test_case_key_exchange_rsp_setup_version_capabilities},
+     spdm_test_case_key_exchange_rsp_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_UNEXPECTED_REQUEST_IN_SESSION,
      "spdm_test_case_key_exchange_rsp_unexpected_request_in_session",
      spdm_test_case_key_exchange_rsp_unexpected_request_in_session,
-     spdm_test_case_key_exchange_rsp_setup_version_any},
+     spdm_test_case_key_exchange_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_INVALID_REQUEST,
      "spdm_test_case_key_exchange_rsp_invalid_request",
      spdm_test_case_key_exchange_rsp_invalid_request,
-     spdm_test_case_key_exchange_rsp_setup_version_any},
+     spdm_test_case_key_exchange_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_SUCCESS_12,
      "spdm_test_case_key_exchange_rsp_success_12", spdm_test_case_key_exchange_rsp_success_12,
-     spdm_test_case_key_exchange_rsp_setup_version_12},
+     spdm_test_case_key_exchange_rsp_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_KEY_EXCHANGE_RSP_SUCCESS_12_HS_CLEAR,
      "spdm_test_case_key_exchange_rsp_success_12_hs_clear",
      spdm_test_case_key_exchange_rsp_success_12_hs_clear,
-     spdm_test_case_key_exchange_rsp_setup_version_12_hs_clear},
+     spdm_test_case_key_exchange_rsp_setup_version_12_hs_clear,
+     libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -46,6 +46,7 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     if (spdm_version_count != 0) {
         libspdm_zero_mem(&parameter, sizeof(parameter));
@@ -257,6 +258,7 @@ bool spdm_test_case_finish_rsp_setup_version_capabilities (void *test_context)
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
+    libspdm_init_context_for_responder_validator(spdm_context);
 
     status = libspdm_get_version (spdm_context, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
@@ -1458,41 +1460,62 @@ void spdm_test_case_finish_rsp_session_required (void *test_context)
 
 common_test_case_t m_spdm_test_group_finish_rsp[] = {
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_SUCCESS_11, "spdm_test_case_finish_rsp_success_11",
-     spdm_test_case_finish_rsp_success_11, spdm_test_case_finish_rsp_setup_version_11},
+     spdm_test_case_finish_rsp_success_11, spdm_test_case_finish_rsp_setup_version_11,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_SUCCESS_11_HS_CLEAR,
      "spdm_test_case_finish_rsp_success_11_hs_clear",
      spdm_test_case_finish_rsp_success_11_hs_clear,
-     spdm_test_case_finish_rsp_setup_version_11_hs_clear},
+     spdm_test_case_finish_rsp_setup_version_11_hs_clear,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_VERSION_MISMATCH,
      "spdm_test_case_finish_rsp_version_mismatch", spdm_test_case_finish_rsp_version_mismatch,
-     spdm_test_case_finish_rsp_setup_version_any},
+     spdm_test_case_finish_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_UNEXPECTED_REQUEST,
      "spdm_test_case_finish_rsp_unexpected_request",
      spdm_test_case_finish_rsp_unexpected_request,
-     spdm_test_case_finish_rsp_setup_version_capabilities},
+     spdm_test_case_finish_rsp_setup_version_capabilities,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_UNEXPECTED_REQUEST_IN_SESSION,
      "spdm_test_case_finish_rsp_unexpected_request_in_session",
      spdm_test_case_finish_rsp_unexpected_request_in_session,
-     spdm_test_case_finish_rsp_setup_version_any},
+     spdm_test_case_finish_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_INVALID_REQUEST,
      "spdm_test_case_finish_rsp_invalid_request", spdm_test_case_finish_rsp_invalid_request,
-     spdm_test_case_finish_rsp_setup_version_any},
+     spdm_test_case_finish_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_DECRYPT_ERROR_INVALID_VERIFY_DATA,
      "spdm_test_case_finish_rsp_decrypt_error_invalid_verify_data",
      spdm_test_case_finish_rsp_decrypt_error_invalid_verify_data,
-     spdm_test_case_finish_rsp_setup_version_any},
+     spdm_test_case_finish_rsp_setup_version_any,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_DECRYPT_ERROR_INVALID_VERIFY_DATA_HS_CLEAR,
      "spdm_test_case_finish_rsp_decrypt_error_invalid_verify_data_hs_clear",
      spdm_test_case_finish_rsp_decrypt_error_invalid_verify_data_hs_clear,
-     spdm_test_case_finish_rsp_setup_version_any_hs_clear},
+     spdm_test_case_finish_rsp_setup_version_any_hs_clear,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_SUCCESS_12, "spdm_test_case_finish_rsp_success_12",
-     spdm_test_case_finish_rsp_success_12, spdm_test_case_finish_rsp_setup_version_12},
+     spdm_test_case_finish_rsp_success_12, spdm_test_case_finish_rsp_setup_version_12,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_SUCCESS_12_HS_CLEAR,
      "spdm_test_case_finish_rsp_success_12_hs_clear",
      spdm_test_case_finish_rsp_success_12_hs_clear,
-     spdm_test_case_finish_rsp_setup_version_12_hs_clear},
+     spdm_test_case_finish_rsp_setup_version_12_hs_clear,
+     libspdm_deinit_context_for_responder_validator},
+
     {SPDM_RESPONDER_TEST_CASE_FINISH_RSP_SESSION_REQUIRED,
      "spdm_test_case_finish_rsp_session_required", spdm_test_case_finish_rsp_session_required,
-     spdm_test_case_finish_rsp_setup_version_12},
+     spdm_test_case_finish_rsp_setup_version_12, libspdm_deinit_context_for_responder_validator},
+
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_support.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_support.c
@@ -34,3 +34,158 @@ uint32_t spdm_test_get_one_bit (uint32_t data, uint32_t mask)
     }
     return final;
 }
+
+/**
+ * Initialize an SPDM context for SPDM-Responder-Validator, as well as secured message contexts.
+ * The secured message contexts are appended to the context structure.
+ *
+ * The total size in bytes of the spdm_context and all secured message
+ * contexts can be returned by libspdm_get_context_size().
+ *
+ * @param  spdm_context         A pointer to the SPDM context.
+ *
+ * @retval RETURN_SUCCESS       context is initialized.
+ * @retval RETURN_DEVICE_ERROR  context initialization failed.
+ */
+libspdm_return_t libspdm_init_context_for_responder_validator(void *context)
+{
+    libspdm_context_t *spdm_context;
+    void *secured_context;
+    void *secured_contexts[LIBSPDM_MAX_SESSION_COUNT];
+    size_t secured_context_size;
+    size_t index;
+
+    LIBSPDM_ASSERT(context != NULL);
+
+    /* libspdm_get_context_size() allocates space for all secured message
+     * contexts. They are appended to the general SPDM context. */
+    spdm_context = context;
+    secured_context = (void *)((size_t)(spdm_context + 1));
+    secured_context_size = libspdm_secured_message_get_context_size();
+
+    for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++)
+    {
+        secured_contexts[index] =
+            (uint8_t *)secured_context + secured_context_size * index;
+    }
+
+    /* the different code between libspdm_init_context_for_responder_validator and libspdm_init_context
+     * the libspdm_init_context is libspdm_zero_mem(spdm_context, sizeof(libspdm_context_t));
+     * After libspdm_init_context_for_responder_validator, device don't need to register_device functon again.
+     **/
+    libspdm_zero_mem(&(spdm_context->version), sizeof(spdm_context->version));
+    libspdm_zero_mem(&(spdm_context->transcript), sizeof(spdm_context->transcript));
+    libspdm_zero_mem(&(spdm_context->spdm_session_state_callback),
+                     sizeof(spdm_context->spdm_session_state_callback));
+    libspdm_zero_mem(&(spdm_context->spdm_key_update_callback),
+                     sizeof(spdm_context->spdm_key_update_callback));
+    libspdm_zero_mem(&(spdm_context->spdm_connection_state_callback),
+                     sizeof(spdm_context->spdm_connection_state_callback));
+    libspdm_zero_mem(&(spdm_context->session_info), sizeof(spdm_context->session_info));
+    libspdm_zero_mem(&(spdm_context->sender_buffer_size),
+                     sizeof(spdm_context->sender_buffer_size));
+    libspdm_zero_mem(&(spdm_context->sender_buffer), sizeof(spdm_context->sender_buffer));
+    libspdm_zero_mem(&(spdm_context->retry_times), sizeof(spdm_context->retry_times));
+    libspdm_zero_mem(&(spdm_context->response_state), sizeof(spdm_context->response_state));
+    libspdm_zero_mem(&(spdm_context->receiver_buffer_size),
+                     sizeof(spdm_context->receiver_buffer_size));
+    libspdm_zero_mem(&(spdm_context->receiver_buffer), sizeof(spdm_context->receiver_buffer));
+    libspdm_zero_mem(&(spdm_context->msg_log), sizeof(spdm_context->msg_log));
+    libspdm_zero_mem(&(spdm_context->local_context), sizeof(spdm_context->local_context));
+    libspdm_zero_mem(&(spdm_context->latest_session_id), sizeof(spdm_context->latest_session_id));
+    libspdm_zero_mem(&(spdm_context->last_spdm_request_size),
+                     sizeof(spdm_context->last_spdm_request_size));
+    libspdm_zero_mem(&(spdm_context->last_spdm_request_session_id_valid),
+                     sizeof(spdm_context->last_spdm_request_session_id_valid));
+    libspdm_zero_mem(&(spdm_context->last_spdm_request_session_id),
+                     sizeof(spdm_context->last_spdm_request_session_id));
+    libspdm_zero_mem(&(spdm_context->last_spdm_request), sizeof(spdm_context->last_spdm_request));
+    libspdm_zero_mem(&(spdm_context->last_spdm_error), sizeof(spdm_context->last_spdm_error));
+    libspdm_zero_mem(&(spdm_context->handle_error_return_policy),
+                     sizeof(spdm_context->handle_error_return_policy));
+    libspdm_zero_mem(&(spdm_context->get_response_func),
+                     sizeof(spdm_context->get_response_func));
+    libspdm_zero_mem(&(spdm_context->get_encap_response_func),
+                     sizeof(spdm_context->get_encap_response_func));
+    libspdm_zero_mem(&(spdm_context->error_data), sizeof(spdm_context->error_data));
+    libspdm_zero_mem(&(spdm_context->encap_context), sizeof(spdm_context->encap_context));
+    libspdm_zero_mem(&(spdm_context->current_token), sizeof(spdm_context->current_token));
+    libspdm_zero_mem(&(spdm_context->crypto_request), sizeof(spdm_context->crypto_request));
+    libspdm_zero_mem(&(spdm_context->connection_info), sizeof(spdm_context->connection_info));
+#if LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP || LIBSPDM_ENABLE_CHUNK_CAP
+    libspdm_zero_mem(&(spdm_context->chunk_context), sizeof(spdm_context->chunk_context));
+#endif
+    libspdm_zero_mem(&(spdm_context->cache_spdm_request_size),
+                     sizeof(spdm_context->cache_spdm_request_size));
+    libspdm_zero_mem(&(spdm_context->cache_spdm_request), sizeof(spdm_context->cache_spdm_request));
+    libspdm_zero_mem(&(spdm_context->app_context_data_ptr),
+                     sizeof(spdm_context->app_context_data_ptr));
+
+    spdm_context->version = libspdm_context_struct_version;
+    spdm_context->transcript.message_a.max_buffer_size =
+        sizeof(spdm_context->transcript.message_a.buffer);
+#if LIBSPDM_RECORD_TRANSCRIPT_DATA_SUPPORT
+    spdm_context->transcript.message_b.max_buffer_size =
+        sizeof(spdm_context->transcript.message_b.buffer);
+    spdm_context->transcript.message_c.max_buffer_size =
+        sizeof(spdm_context->transcript.message_c.buffer);
+    spdm_context->transcript.message_mut_b.max_buffer_size =
+        sizeof(spdm_context->transcript.message_mut_b.buffer);
+    spdm_context->transcript.message_mut_c.max_buffer_size =
+        sizeof(spdm_context->transcript.message_mut_c.buffer);
+    spdm_context->transcript.message_m.max_buffer_size =
+        sizeof(spdm_context->transcript.message_m.buffer);
+#endif
+    spdm_context->retry_times = LIBSPDM_MAX_REQUEST_RETRY_TIMES;
+    spdm_context->response_state = LIBSPDM_RESPONSE_STATE_NORMAL;
+    spdm_context->current_token = 0;
+    spdm_context->local_context.version.spdm_version_count = 3;
+    spdm_context->local_context.version.spdm_version[0] = SPDM_MESSAGE_VERSION_10 <<
+                                                          SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[1] = SPDM_MESSAGE_VERSION_11 <<
+                                                          SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.version.spdm_version[2] = SPDM_MESSAGE_VERSION_12 <<
+                                                          SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.secured_message_version.spdm_version_count = 1;
+    spdm_context->local_context.secured_message_version.spdm_version[0] =
+        SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->local_context.capability.st1 = SPDM_ST1_VALUE_US;
+
+    spdm_context->encap_context.certificate_chain_buffer.max_buffer_size =
+        sizeof(spdm_context->encap_context.certificate_chain_buffer.buffer);
+
+    /* From the config.h, need different value for CHUNK - TBD*/
+    spdm_context->local_context.capability.data_transfer_size = LIBSPDM_DATA_TRANSFER_SIZE;
+    spdm_context->local_context.capability.max_spdm_msg_size = LIBSPDM_MAX_SPDM_MSG_SIZE;
+
+    for (index = 0; index < LIBSPDM_MAX_SESSION_COUNT; index++) {
+        if (secured_contexts[index] == NULL) {
+            return LIBSPDM_STATUS_INVALID_PARAMETER;
+        }
+
+        spdm_context->session_info[index].secured_message_context = secured_contexts[index];
+        libspdm_secured_message_init_context(
+            spdm_context->session_info[index]
+            .secured_message_context);
+    }
+
+    return LIBSPDM_STATUS_SUCCESS;
+}
+
+/**
+ * Free the memory of contexts within the SPDM context.
+ * These are typically contexts whose memory has been allocated by the cryptography library.
+ * This function does not free the SPDM context itself.
+ *
+ * @param[in]  spdm_context         A pointer to the SPDM context.
+ *
+ */
+void libspdm_deinit_context_for_responder_validator(void *test_context)
+{
+    spdm_test_context_t *spdm_test_context;
+    void *spdm_context;
+
+    spdm_test_context = test_context;
+    spdm_context = spdm_test_context->spdm_context;
+    libspdm_deinit_context(spdm_context);
+}


### PR DESCRIPTION
Fix: #24
Add `init_context_for_validator` in every case setup function; 
Add `deinit_context_for_validator` in every case teardown function;

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>