### PR TITLE
Fix test capability after clean context

### DIFF
--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -159,7 +159,7 @@ Assertion 2.4.5:
 
 Assertion 2.4.*.
 
-5. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, Flags=CERT_CAP|CHAL_CAP|ENCRYPT_CAP|MAC_CAP|MUT_AUTH_CAP|KEY_EX_CAP|PSK_CAP=1|HBEAT_CAP|KEY_UPD_CAP} -- if NegotiatedVersion=1.1+
+5. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, Flags=CERT_CAP|CHAL_CAP|ENCRYPT_CAP|MAC_CAP|MUT_AUTH_CAP|KEY_EX_CAP|PSK_CAP=1|HBEAT_CAP|KEY_UPD_CAP} -- if NegotiatedVersion=1.1 only
 6. SpdmMessage <- Responder
 
 Assertion 2.4.*.

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -633,6 +633,14 @@ void spdm_test_case_capabilities_invalid_request (void *test_context)
                 }
                 spdm_request_new.header.spdm_version = version;
                 spdm_request_new.flags = invalid_flags_v11[index];
+
+                /*the mut_auth_cap == 1 and encap_cap == 0 case need check for version1.1 only*/
+                if (index == 2) {
+                    version = SPDM_MESSAGE_VERSION_11;
+                    spdm_request_size =
+                        offsetof(spdm_get_capabilities_request_t, data_transfer_size);
+                    spdm_request_new.header.spdm_version = version;
+                }
             } else {
                 continue;
             }


### PR DESCRIPTION
Fix: #49
Make the` mut_auth_cap == 1 and encap_cap == 0`  test v11 flags check  only for version1.1

Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>