### PR TITLE
Update conformance test to match lateast libspdm

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -148,7 +148,7 @@ bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, 0, NULL, NULL);
+    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -148,7 +148,7 @@ bool spdm_test_case_key_update_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, 0, NULL, NULL);
+    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -147,7 +147,7 @@ bool spdm_test_case_end_session_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, 0, NULL, NULL);
+    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -149,7 +149,7 @@ bool spdm_test_case_certificate_setup_vca_digest (void *test_context,
                      &data_size);
     test_buffer->hash_size = libspdm_get_hash_size(test_buffer->hash_algo);
 
-    status = libspdm_get_digest (spdm_context, &test_buffer->slot_mask,
+    status = libspdm_get_digest (spdm_context, NULL, &test_buffer->slot_mask,
                                  test_buffer->total_digest_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -161,7 +161,7 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
                      &data_size);
     test_buffer->signature_size = libspdm_get_asym_signature_size(test_buffer->asym_algo);
 
-    status = libspdm_get_digest (spdm_context, &test_buffer->slot_mask,
+    status = libspdm_get_digest (spdm_context, NULL, &test_buffer->slot_mask,
                                  test_buffer->total_digest_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
@@ -171,7 +171,7 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
         if ((test_buffer->slot_mask & (0x1 << slot_id)) == 0) {
             continue;
         }
-        status = libspdm_get_certificate (spdm_context, slot_id, NULL, NULL);
+        status = libspdm_get_certificate (spdm_context, NULL, slot_id, NULL, NULL);
     }
 
     test_buffer->slot_count = 0;
@@ -390,7 +390,7 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
 
             if ((message_mask & SPDM_MESSAGE_A_MASK_VCA) == 0) {
                 status =
-                    libspdm_challenge (spdm_context, slot_id,
+                    libspdm_challenge (spdm_context, NULL, slot_id,
                                        measurement_hash_type[meas_hash_type_index], NULL, NULL);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
                     common_test_record_test_assertion (
@@ -401,7 +401,7 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
             }
 
             if ((message_mask & SPDM_MESSAGE_B_MASK_GET_DIGESTS) != 0) {
-                status = libspdm_get_digest (spdm_context, NULL, NULL);
+                status = libspdm_get_digest (spdm_context, NULL, NULL, NULL);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
                     common_test_record_test_assertion (
                         SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, COMMON_TEST_ID_END,
@@ -412,8 +412,8 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
 
             if ((message_mask & SPDM_MESSAGE_B_MASK_GET_CERTIFICATE) != 0) {
                 cert_chain_buffer_size = sizeof(cert_chain_buffer);
-                status = libspdm_get_certificate (spdm_context, slot_id, &cert_chain_buffer_size,
-                                                  cert_chain_buffer);
+                status = libspdm_get_certificate (spdm_context, NULL, slot_id,
+                                                  &cert_chain_buffer_size, cert_chain_buffer);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
                     common_test_record_test_assertion (
                         SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, COMMON_TEST_ID_END,

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -159,7 +159,7 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
                      &data_size);
     test_buffer->signature_size = libspdm_get_asym_signature_size(test_buffer->asym_algo);
 
-    status = libspdm_get_digest (spdm_context, &test_buffer->slot_mask, NULL);
+    status = libspdm_get_digest (spdm_context, NULL, &test_buffer->slot_mask, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
@@ -171,12 +171,13 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
         }
     }
 
-    status = libspdm_get_certificate (spdm_context, 0, NULL, NULL);
+    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
 
-    status = libspdm_challenge (spdm_context, 0, SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH,
+    status = libspdm_challenge (spdm_context, NULL, 0,
+                                SPDM_CHALLENGE_REQUEST_ALL_MEASUREMENTS_HASH,
                                 &test_buffer->measurement_summary_hash, NULL);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -190,14 +190,15 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
                      &test_buffer->dhe_named_group, &data_size);
     test_buffer->dhe_key_size = libspdm_get_dhe_pub_key_size(test_buffer->dhe_named_group);
 
-    status = libspdm_get_digest (spdm_context, &test_buffer->slot_mask,
+    status = libspdm_get_digest (spdm_context, NULL, &test_buffer->slot_mask,
                                  test_buffer->total_digest_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
 
     cert_chain_buffer_size = sizeof(cert_chain_buffer);
-    status = libspdm_get_certificate (spdm_context, 0, &cert_chain_buffer_size, cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &cert_chain_buffer_size, cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
@@ -425,8 +426,8 @@ void spdm_test_case_key_exchange_rsp_success_11_12 (void *test_context, uint8_t 
             }
 
             cert_chain_buffer_size = sizeof(cert_chain_buffer);
-            status = libspdm_get_certificate (spdm_context, slot_id, &cert_chain_buffer_size,
-                                              cert_chain_buffer);
+            status = libspdm_get_certificate (spdm_context, NULL, slot_id,
+                                              &cert_chain_buffer_size, cert_chain_buffer);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
                 common_test_record_test_assertion (
                     SPDM_RESPONDER_TEST_GROUP_KEY_EXCHANGE_RSP, case_id, COMMON_TEST_ID_END,

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -169,14 +169,15 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
                      &data_size);
     test_buffer->hash_size = libspdm_get_hash_size(test_buffer->hash_algo);
 
-    status = libspdm_get_digest (spdm_context, &test_buffer->slot_mask,
+    status = libspdm_get_digest (spdm_context, NULL, &test_buffer->slot_mask,
                                  test_buffer->total_digest_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
 
     cert_chain_buffer_size = sizeof(cert_chain_buffer);
-    status = libspdm_get_certificate (spdm_context, 0, &cert_chain_buffer_size, cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &cert_chain_buffer_size, cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
@@ -379,8 +380,8 @@ void spdm_test_case_finish_rsp_success_11_12 (void *test_context, uint8_t versio
         }
 
         cert_chain_buffer_size = sizeof(cert_chain_buffer);
-        status = libspdm_get_certificate (spdm_context, slot_id, &cert_chain_buffer_size,
-                                          cert_chain_buffer);
+        status = libspdm_get_certificate (spdm_context, NULL, slot_id,
+                                          &cert_chain_buffer_size, cert_chain_buffer);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             common_test_record_test_assertion (
                 SPDM_RESPONDER_TEST_GROUP_FINISH_RSP, case_id, COMMON_TEST_ID_END,


### PR DESCRIPTION
This is adjunctive update of conformance test
to match the latest APIs change of libspdm, no functionality change.
DMTF/libspdm#1639
DMTF/libspdm#1652

Signed-off-by: Xiangfei Ma <xiangfei.ma@samsung.com>