### PR TITLE
Change `libspdm_const_compare_mem` to standard C `memcmp`

### DIFF
--- a/common_test_framework/include/library/common_test_utility_lib.h
+++ b/common_test_framework/include/library/common_test_utility_lib.h
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdarg.h>
+#include <string.h>
 
 typedef uint32_t common_test_group_id;
 typedef uint32_t common_test_case_id;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -372,10 +372,9 @@ void spdm_test_case_certificate_success_10 (void *test_context)
                 COMMON_TEST_RESULT_NOT_TESTED, "calc_cert_hash failure");
             return;
         }
-        if (libspdm_const_compare_mem (cert_chain_hash,
-                                       &test_buffer->total_digest_buffer[hash_index *
-                                                                         test_buffer->hash_size],
-                                       test_buffer->hash_size) == 0) {
+        if (memcmp (cert_chain_hash,
+                    &test_buffer->total_digest_buffer[hash_index * test_buffer->hash_size],
+                    test_buffer->hash_size) == 0) {
             test_result = COMMON_TEST_RESULT_PASS;
         } else {
             test_result = COMMON_TEST_RESULT_FAIL;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -530,10 +530,9 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                 return;
             }
 
-            if (libspdm_const_compare_mem (cert_chain_hash_ptr,
-                                           &test_buffer->total_digest_buffer[hash_index *
-                                                                             test_buffer->hash_size],
-                                           test_buffer->hash_size) == 0) {
+            if (memcmp (cert_chain_hash_ptr,
+                        &test_buffer->total_digest_buffer[hash_index * test_buffer->hash_size],
+                        test_buffer->hash_size) == 0) {
                 test_result = COMMON_TEST_RESULT_PASS;
             } else {
                 test_result = COMMON_TEST_RESULT_FAIL;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -958,9 +958,8 @@ void spdm_test_case_measurements_success_10_11_12 (void *test_context, uint8_t v
                 COMMON_TEST_RESULT_NOT_TESTED, "calc_summary_hash failure");
             return;
         }
-        if (libspdm_const_compare_mem (measurement_summary_hash,
-                                       test_buffer->measurement_summary_hash,
-                                       test_buffer->hash_size) == 0) {
+        if (memcmp (measurement_summary_hash,
+                    test_buffer->measurement_summary_hash, test_buffer->hash_size) == 0) {
             test_result = COMMON_TEST_RESULT_PASS;
         } else {
             test_result = COMMON_TEST_RESULT_FAIL;
@@ -1186,9 +1185,8 @@ void spdm_test_case_measurements_success_10_11_12 (void *test_context, uint8_t v
                 return;
             }
 
-            if (libspdm_const_compare_mem ((void *)(spdm_response + 1),
-                                           measurement_record_out,
-                                           measurement_record_length_out) == 0) {
+            if (memcmp ((void *)(spdm_response + 1),
+                         measurement_record_out, measurement_record_length_out) == 0) {
                 test_result = COMMON_TEST_RESULT_PASS;
             } else {
                 test_result = COMMON_TEST_RESULT_FAIL;


### PR DESCRIPTION
See https://github.com/DMTF/libspdm/issues/1585

In particular, the test itself does not need a constant-time compare function, so better to use the C standard library.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>