### PR TITLE
Certificate chain buffer must be provided

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -15,6 +15,9 @@ typedef struct {
 } spdm_heartbeat_ack_test_buffer_t;
 #pragma pack()
 
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
+
 bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
                                                  spdm_version_number_t spdm_version,
                                                  bool need_session)
@@ -148,7 +151,9 @@ bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -14,6 +14,9 @@ typedef struct {
 } spdm_key_update_ack_test_buffer_t;
 #pragma pack()
 
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
+
 bool spdm_test_case_key_update_ack_setup_session (void *test_context,
                                                   spdm_version_number_t spdm_version,
                                                   bool need_session)
@@ -148,7 +151,9 @@ bool spdm_test_case_key_update_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -15,6 +15,9 @@ typedef struct {
 } spdm_end_session_ack_test_buffer_t;
 #pragma pack()
 
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
+
 bool spdm_test_case_end_session_ack_setup_session (void *test_context,
                                                    spdm_version_number_t spdm_version,
                                                    bool need_session)
@@ -147,7 +150,9 @@ bool spdm_test_case_end_session_ack_setup_session (void *test_context,
         return false;
     }
 
-    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -24,6 +24,9 @@ typedef struct {
 } spdm_challenge_auth_test_buffer_t;
 #pragma pack()
 
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
+
 bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
                                                      size_t spdm_version_count,
                                                      spdm_version_number_t *spdm_version)
@@ -171,7 +174,9 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
         if ((test_buffer->slot_mask & (0x1 << slot_id)) == 0) {
             continue;
         }
-        status = libspdm_get_certificate (spdm_context, NULL, slot_id, NULL, NULL);
+        m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
+        status = libspdm_get_certificate (spdm_context, NULL, slot_id, &m_cert_chain_buffer_size,
+                                          m_cert_chain_buffer);
     }
 
     test_buffer->slot_count = 0;
@@ -276,8 +281,6 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
     spdm_challenge_auth_response_t *spdm_response;
     uint8_t message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     size_t spdm_response_size;
-    uint8_t cert_chain_buffer[LIBSPDM_MAX_CERT_CHAIN_SIZE];
-    size_t cert_chain_buffer_size;
     common_test_result_t test_result;
     spdm_challenge_auth_test_buffer_t *test_buffer;
     uint8_t slot_id;
@@ -411,9 +414,9 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
             }
 
             if ((message_mask & SPDM_MESSAGE_B_MASK_GET_CERTIFICATE) != 0) {
-                cert_chain_buffer_size = sizeof(cert_chain_buffer);
+                m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
                 status = libspdm_get_certificate (spdm_context, NULL, slot_id,
-                                                  &cert_chain_buffer_size, cert_chain_buffer);
+                                                  &m_cert_chain_buffer_size, m_cert_chain_buffer);
                 if (LIBSPDM_STATUS_IS_ERROR(status)) {
                     common_test_record_test_assertion (
                         SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, COMMON_TEST_ID_END,

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -22,6 +22,9 @@ typedef struct {
 } spdm_measurements_test_buffer_t;
 #pragma pack()
 
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
+
 bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context, bool need_session,
                                                               size_t spdm_version_count,
                                                               spdm_version_number_t *spdm_version)
@@ -171,7 +174,9 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
         }
     }
 
-    status = libspdm_get_certificate (spdm_context, NULL, 0, NULL, NULL);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
+    status = libspdm_get_certificate (spdm_context, NULL, 0,
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -20,9 +20,7 @@ typedef struct {
     uint8_t slot_count;
     uint8_t total_digest_buffer[SPDM_MAX_SLOT_COUNT * LIBSPDM_MAX_HASH_SIZE];
 } spdm_key_exchange_rsp_test_buffer_t;
-#pragma pack()
 
-#pragma pack(1)
 typedef struct {
     spdm_message_header_t header;
     uint16_t req_session_id;
@@ -33,8 +31,10 @@ typedef struct {
     uint16_t opaque_length;
     uint8_t opaque_data[SPDM_MAX_OPAQUE_DATA_SIZE];
 } spdm_key_exchange_request_mine_t;
-
 #pragma pack()
+
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
 
 bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
                                                        size_t spdm_version_count,
@@ -52,8 +52,6 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
     uint8_t data8;
     spdm_key_exchange_rsp_test_buffer_t *test_buffer;
     size_t index;
-    uint8_t cert_chain_buffer[LIBSPDM_MAX_CERT_CHAIN_SIZE];
-    size_t cert_chain_buffer_size;
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
@@ -196,9 +194,9 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
         return false;
     }
 
-    cert_chain_buffer_size = sizeof(cert_chain_buffer);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
     status = libspdm_get_certificate (spdm_context, NULL, 0,
-                                      &cert_chain_buffer_size, cert_chain_buffer);
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
@@ -340,8 +338,6 @@ void spdm_test_case_key_exchange_rsp_success_11_12 (void *test_context, uint8_t 
     spdm_key_exchange_response_t *spdm_response;
     uint8_t message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     size_t spdm_response_size;
-    uint8_t cert_chain_buffer[LIBSPDM_MAX_CERT_CHAIN_SIZE];
-    size_t cert_chain_buffer_size;
     common_test_result_t test_result;
     spdm_key_exchange_rsp_test_buffer_t *test_buffer;
     uint8_t slot_id;
@@ -425,9 +421,9 @@ void spdm_test_case_key_exchange_rsp_success_11_12 (void *test_context, uint8_t 
                 continue;
             }
 
-            cert_chain_buffer_size = sizeof(cert_chain_buffer);
+            m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
             status = libspdm_get_certificate (spdm_context, NULL, slot_id,
-                                              &cert_chain_buffer_size, cert_chain_buffer);
+                                              &m_cert_chain_buffer_size, m_cert_chain_buffer);
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
                 common_test_record_test_assertion (
                     SPDM_RESPONDER_TEST_GROUP_KEY_EXCHANGE_RSP, case_id, COMMON_TEST_ID_END,

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -16,15 +16,15 @@ typedef struct {
     uint8_t slot_count;
     uint8_t total_digest_buffer[SPDM_MAX_SLOT_COUNT * LIBSPDM_MAX_HASH_SIZE];
 } spdm_finish_rsp_test_buffer_t;
-#pragma pack()
 
-#pragma pack(1)
 typedef struct {
     spdm_message_header_t header;
     uint8_t verify_data[LIBSPDM_MAX_HASH_SIZE];
 } spdm_finish_request_mine_t;
-
 #pragma pack()
+
+static uint8_t m_cert_chain_buffer[SPDM_MAX_CERTIFICATE_CHAIN_SIZE];
+static size_t m_cert_chain_buffer_size;
 
 bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
                                                  size_t spdm_version_count,
@@ -41,8 +41,6 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
     uint8_t data8;
     spdm_finish_rsp_test_buffer_t *test_buffer;
     size_t index;
-    uint8_t cert_chain_buffer[LIBSPDM_MAX_CERT_CHAIN_SIZE];
-    size_t cert_chain_buffer_size;
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
@@ -175,9 +173,9 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
         return false;
     }
 
-    cert_chain_buffer_size = sizeof(cert_chain_buffer);
+    m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
     status = libspdm_get_certificate (spdm_context, NULL, 0,
-                                      &cert_chain_buffer_size, cert_chain_buffer);
+                                      &m_cert_chain_buffer_size, m_cert_chain_buffer);
     if (LIBSPDM_STATUS_IS_ERROR(status)) {
         return false;
     }
@@ -321,8 +319,6 @@ void spdm_test_case_finish_rsp_success_11_12 (void *test_context, uint8_t versio
     spdm_finish_response_t *spdm_response;
     uint8_t message[LIBSPDM_MAX_MESSAGE_BUFFER_SIZE];
     size_t spdm_response_size;
-    uint8_t cert_chain_buffer[LIBSPDM_MAX_CERT_CHAIN_SIZE];
-    size_t cert_chain_buffer_size;
     common_test_result_t test_result;
     spdm_finish_rsp_test_buffer_t *test_buffer;
     uint8_t slot_id;
@@ -379,9 +375,9 @@ void spdm_test_case_finish_rsp_success_11_12 (void *test_context, uint8_t versio
             continue;
         }
 
-        cert_chain_buffer_size = sizeof(cert_chain_buffer);
+        m_cert_chain_buffer_size = sizeof(m_cert_chain_buffer);
         status = libspdm_get_certificate (spdm_context, NULL, slot_id,
-                                          &cert_chain_buffer_size, cert_chain_buffer);
+                                          &m_cert_chain_buffer_size, m_cert_chain_buffer);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             common_test_record_test_assertion (
                 SPDM_RESPONDER_TEST_GROUP_FINISH_RSP, case_id, COMMON_TEST_ID_END,


### PR DESCRIPTION
https://github.com/DMTF/libspdm/pull/1835 made it so that a certificate chain must be provided by the Integrator.

Signed-off-by: Steven Bellock <sbellock@nvidia.com>