### PR TITLE
zero parameter even if spdm_version_count==0

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -36,8 +36,9 @@ bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -35,8 +35,9 @@ bool spdm_test_case_key_update_ack_setup_session (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -36,8 +36,9 @@ bool spdm_test_case_end_session_ack_setup_session (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
@@ -44,8 +44,9 @@ bool spdm_test_case_algorithms_setup_version_capabilities (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
@@ -31,8 +31,9 @@ bool spdm_test_case_digests_setup_vca (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -35,8 +35,9 @@ bool spdm_test_case_certificate_setup_vca_digest (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          &spdm_version, sizeof(spdm_version));

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -47,8 +47,9 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version_count != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          spdm_version, sizeof(spdm_version_number_t) * spdm_version_count);

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -44,8 +44,9 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version_count != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          spdm_version, sizeof(spdm_version_number_t) * spdm_version_count);

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -56,8 +56,9 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version_count != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          spdm_version, sizeof(spdm_version_number_t) * spdm_version_count);

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -45,8 +45,9 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
 
+    libspdm_zero_mem(&parameter, sizeof(parameter));
+
     if (spdm_version_count != 0) {
-        libspdm_zero_mem(&parameter, sizeof(parameter));
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          spdm_version, sizeof(spdm_version_number_t) * spdm_version_count);


### PR DESCRIPTION
fixes issue: Validator skips libspdm_zero_mem(&parameter) if spdm_version_count ==0 #69