### PR TITLE
conformance_test2_capabilities: fixup cap flags

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -797,7 +797,8 @@ void spdm_test_case_capabilities_success_12 (void *test_context)
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-                         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+                         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+                         SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     spdm_request.data_transfer_size = test_buffer->data_transfer_size;
     spdm_request.max_spdm_msg_size = test_buffer->max_spdm_msg_size;
 


### PR DESCRIPTION
# Problem
When running the test suite against a libspdm responder, I noticed a failure at:

```
  test case 2.5 (spdm_test_case_capabilities_success_12) - start 
    test assertion 2.5.1 - FAIL response size - 4
```
I *think* the error is caught here:  https://github.com/DMTF/libspdm/blob/1444a7863bd4bcd114f35904d56b6578bc9bc387/library/spdm_responder_lib/libspdm_rsp_capabilities.c#L186

But I'm not sure why the test does not see an error return status in from `libspdm_send_receive_data()`, instead it fails later at checking the response size. Any ideas?

# Fix

Alternatively, if chunk isn't preferred, I think we need to assert that  `spdm_request.data_transfer_size  == spdm_request.max_spdm_msg_size`

With this change, the test will now pass.

```
test case 2.5 (spdm_test_case_capabilities_success_12) - setup enter
  test case 2.5 (spdm_test_case_capabilities_success_12) - setup exit (1)
  test case 2.5 (spdm_test_case_capabilities_success_12) - start
    test assertion 2.5.1 - PASS response size - 20 
    test assertion 2.5.2 - PASS response code - 0x61
    test assertion 2.5.3 - PASS response version - 0x12
    test assertion 2.5.4 - PASS response flags - 0x003e02d6
    test assertion 2.5.5 - PASS response flags - 0x003e02d6
    test assertion 2.5.6 - PASS response flags - 0x003e02d6
    test assertion 2.5.7 - PASS response flags - 0x003e02d6
    test assertion 2.5.8 - PASS response flags - 0x003e02d6
    test assertion 2.5.13 - PASS response data_transfer_size - 0x00001fdd
    test assertion 2.5.14 - PASS response max_spdm_msg_size - 0x00002000, data_transfer_size - 0x00001fdd
    test assertion 2.5.15 - PASS response flags - 0x003e02d6
  test case 2.5 (spdm_test_case_capabilities_success_12) - stop
  test case 2.5 (spdm_test_case_capabilities_success_12) - teardown enter
```