### PR TITLE
spdm_responder_test_capabilities: fixup test conformance

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -1050,7 +1050,7 @@ void spdm_test_case_capabilities_unexpected_non_identical (void *test_context)
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
     spdm_request.data_transfer_size = test_buffer->data_transfer_size;
-    spdm_request.max_spdm_msg_size = test_buffer->max_spdm_msg_size;
+    spdm_request.max_spdm_msg_size = spdm_request.data_transfer_size;
 
     spdm_response = (void *)message;
     spdm_response_size = sizeof(message);


### PR DESCRIPTION
In spdm_test_case_capabilities_unexpected_non_identical() chunking isn't used, so set `spdm_request.max_spdm_msg_size =
spdm_request.data_transfer_size`. Otherwise an SPDM 1.2 or higher responder will return an error here. Which is not the aim of this test.

Context: I noticed that this test was failing with "First GET_CAPABILITIES failure" when running against a libspdm based responder.