### PR TITLE
remove MeasurementSummaryHash check for 1.0/1.1

### DIFF
--- a/doc/7.Measurements.md
+++ b/doc/7.Measurements.md
@@ -72,10 +72,6 @@ Assertion 7.1.12:
     SpdmMessage.MeasurementRecordLength > 0 &&
     Sum(size of each MeasurementBlock in SpdmMessage.MeasurementRecord) == SpdmMessage.MeasurementRecordLength
 
-Assertion 7.1.13:
-    CHALLENGE_AUTH.MeasurementSummaryHash = hash(Concatenation(MeasurementBlock[0].Measurement,
-MeasurementBlock[1].Measurement, ...)) version 1.0
-
 Assertion 7.1.14:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, L1/L2) version 1.0 success, if Flags.MEAS_CAP == 2
 
@@ -353,10 +349,6 @@ Assertion 7.6.11:
 Assertion 7.6.12:
     SpdmMessage.MeasurementRecordLength > 0 &&
     Sum(size of each MeasurementBlock in SpdmMessage.MeasurementRecord) == SpdmMessage.MeasurementRecordLength
-
-Assertion 7.6.13:
-    CHALLENGE_AUTH.MeasurementSummaryHash = hash(Concatenation(MeasurementBlock[0].Measurement,
-MeasurementBlock[1].Measurement, ...)) version 1.1
 
 Assertion 7.6.14:
     SpdmMessage.Param2.SlotID == ValidSlotID[i], if MEAS_CAP == 2


### PR DESCRIPTION
because of ambiguity of the spec.

Fix: https://github.com/DMTF/SPDM-Responder-Validator/issues/99