### PR TITLE
fix for skipped test group digests/certificate for v1.0/1.1

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
@@ -151,7 +151,7 @@ bool spdm_test_case_digests_setup_vca (void *test_context,
 
 bool spdm_test_case_digests_setup_version_any (void *test_context)
 {
-    return spdm_test_case_digests_setup_vca (test_context, 0);
+    return spdm_test_case_digests_setup_vca (test_context, SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
 bool spdm_test_case_digests_setup_version_capabilities (void *test_context)

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -172,7 +172,7 @@ bool spdm_test_case_certificate_setup_vca_digest (void *test_context,
 
 bool spdm_test_case_certificate_setup_version_any (void *test_context)
 {
-    return spdm_test_case_certificate_setup_vca_digest (test_context, 0);
+    return spdm_test_case_certificate_setup_vca_digest (test_context, SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
 bool spdm_test_case_certificate_setup_version_capabilities (void *test_context)


### PR DESCRIPTION
Created issue in spdm-responder-validator repo: https://github.com/DMTF/SPDM-Responder-Validator/issues/102 