### PR TITLE
Fix doc/code mismatch on FINISH case 9.4

### DIFF
--- a/doc/9.FinishRsp.md
+++ b/doc/9.FinishRsp.md
@@ -130,7 +130,7 @@ Assertion 9.3.*.
 
 ### Case 9.4
 
-Description: SPDM responder shall return ERROR(UnexpectedRequest), if it receives a FINISH before KEY_EXCHANGE.
+Description: SPDM responder shall return ERROR(UnexpectedRequest), if it receives a FINISH before NEGOTIATE_ALGORITHMS.
 
 SPDM Version: 1.1+
 
@@ -141,8 +141,6 @@ TestSetup:
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.KEY_EX_CAP == 0, then skip this case.
-7. Requester -> NEGOTIATE_ALGORITHMS {SPDMVersion=NegotiatedVersion, ...}
-8. ALGORITHMS <- Responder
 
 TestTeardown: None
 


### PR DESCRIPTION
The doc expects UnexpectedRequest, before KEY_EXCHANGE. But the code only send VC without ALGORITHM.

However, if VCA is used, then the error is SessionRequired. That also makes sense, because without KEY_EXCHANGE there is no session.

As such, just fix the doc to match the code.