### PR TITLE
Remove MeasurementSummaryHash consistency

### DIFF
--- a/doc/7.Measurements.md
+++ b/doc/7.Measurements.md
@@ -463,10 +463,6 @@ Assertion 7.7.12:
     SpdmMessage.MeasurementRecordLength > 0 &&
     Sum(size of each MeasurementBlock in SpdmMessage.MeasurementRecord) == SpdmMessage.MeasurementRecordLength
 
-Assertion 7.7.13:
-    KEY_EXCHANGE_RSP.MeasurementSummaryHash = hash(Concatenation(MeasurementBlock[0].Measurement,
-MeasurementBlock[1].Measurement, ...)) version 1.1
-
 Assertion 7.7.14:
     SpdmMessage.Param2.SlotID == ValidSlotID[i], if MEAS_CAP == 2
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, L1/L2) version 1.1 success, if Flags.MEAS_CAP == 2
@@ -620,10 +616,6 @@ Assertion 7.9.12:
     SpdmMessage.MeasurementRecordLength > 0 &&
     Sum(size of each MeasurementBlock in SpdmMessage.MeasurementRecord) == SpdmMessage.MeasurementRecordLength
 
-Assertion 7.9.13:
-    CHALLENGE_AUTH.MeasurementSummaryHash = hash(Concatenation(MeasurementBlock[0],
-MeasurementBlock[1], ...)) version 1.2
-
 Assertion 7.9.14:
     SpdmMessage.Param2.SlotID == ValidSlotID[i] &&
     (SpdmMessage.Param2.ContentChanged == NotSupported || SpdmMessage.Param2.ContentChanged == NoChange), if MEAS_CAP == 2
@@ -736,10 +728,6 @@ Assertion 7.10.11:
 Assertion 7.10.12:
     SpdmMessage.MeasurementRecordLength > 0 &&
     Sum(size of each MeasurementBlock in SpdmMessage.MeasurementRecord) == SpdmMessage.MeasurementRecordLength
-
-Assertion 7.10.13:
-    KEY_EXCHANGE_RSP.MeasurementSummaryHash = hash(Concatenation(MeasurementBlock[0].Measurement,
-MeasurementBlock[1].Measurement, ...)) version 1.2
 
 Assertion 7.10.14:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, L1/L2) version 1.2 success, if Flags.MEAS_CAP == 2

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -951,7 +951,6 @@ void spdm_test_case_measurements_success_10_11_12 (void *test_context, uint8_t v
         measurement_record_size = measurement_record_length;
         measurement_block_count = spdm_response->number_of_blocks;
 
-        
         result = spdm_test_measurement_calc_summary_hash (test_buffer->version,
                                                             test_buffer->hash_algo,
                                                             spdm_response->number_of_blocks,
@@ -959,26 +958,6 @@ void spdm_test_case_measurements_success_10_11_12 (void *test_context, uint8_t v
                                                             (void *)(spdm_response + 1),
                                                             measurement_summary_hash,
                                                             measurement_index_mask);
-        if (version >= SPDM_MESSAGE_VERSION_12) {
-            if (!result) {
-                common_test_record_test_assertion (
-                    SPDM_RESPONDER_TEST_GROUP_MEASUREMENTS, case_id, COMMON_TEST_ID_END,
-                    COMMON_TEST_RESULT_NOT_TESTED, "calc_summary_hash failure");
-                return;
-            }
-            if (memcmp (measurement_summary_hash,
-                        test_buffer->measurement_summary_hash, test_buffer->hash_size) == 0) {
-                test_result = COMMON_TEST_RESULT_PASS;
-            } else {
-                test_result = COMMON_TEST_RESULT_FAIL;
-            }
-            common_test_record_test_assertion (
-                SPDM_RESPONDER_TEST_GROUP_MEASUREMENTS, case_id, 13,
-                test_result, "response measurement summary hash");
-            if (test_result == COMMON_TEST_RESULT_FAIL) {
-                return;
-            }
-        }
 
         if ((test_buffer->rsp_cap_flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG) != 0) {
 


### PR DESCRIPTION
The reason is that there is no guarantee the MeasurementSummaryHash is unchanged.