### PR TITLE
README: remove depreacted test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ void *spdm_test_client_init(void)
    ```
 common_test_case_config_t m_spdm_test_group_version_configs[] = {
     {SPDM_RESPONDER_TEST_CASE_VERSION_SUCCESS_10, COMMON_TEST_ACTION_RUN},
-    {SPDM_RESPONDER_TEST_CASE_VERSION_INVALID_REQUEST, COMMON_TEST_ACTION_RUN},
     {COMMON_TEST_ID_END, COMMON_TEST_ACTION_SKIP},
 };
 


### PR DESCRIPTION
Fixes up the `README` to reflect the changes in: https://github.com/DMTF/SPDM-Responder-Validator/pull/125