### PR TITLE
Update test case 1 (Version) to support SPDM 1.3

### DIFF
--- a/doc/1.Version.md
+++ b/doc/1.Version.md
@@ -28,5 +28,5 @@ Assertion 1.1.4:
     SpdmMessage.VersionNumberEntryCount <= (sizeof(SpdmMessage) - offset(VERSION, VersionNumberEntry)) / sizeof(uint16_t)
 
 Assertion 1.1.5:
-    ((SpdmMessage.VersionNumberEntry[i].MajorVersion << 4) + SpdmMessage.VersionNumberEntry[i].MinorVersion) is in {0x10, 0x11, 0x12}.
+    ((SpdmMessage.VersionNumberEntry[i].MajorVersion << 4) + SpdmMessage.VersionNumberEntry[i].MinorVersion) is in {0x10, 0x11, 0x12, 0x13}.
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_1_version.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_1_version.c
@@ -100,13 +100,17 @@ void spdm_test_case_version_success (void *test_context)
 
     version_number_entry = (void *)(spdm_response + 1);
     for (index = 0; index < spdm_response->version_number_entry_count; index++) {
-        version = version_number_entry[index];
-        version = version >> SPDM_VERSION_NUMBER_SHIFT_BIT;
-        if (version == SPDM_MESSAGE_VERSION_10 || version == SPDM_MESSAGE_VERSION_11 ||
-            version == SPDM_MESSAGE_VERSION_12) {
-            test_result = COMMON_TEST_RESULT_PASS;
-        } else {
-            test_result = COMMON_TEST_RESULT_FAIL;
+        version = version_number_entry[index] >> SPDM_VERSION_NUMBER_SHIFT_BIT;
+        switch (version) {
+            case SPDM_MESSAGE_VERSION_10:
+            case SPDM_MESSAGE_VERSION_11:
+            case SPDM_MESSAGE_VERSION_12:
+            case SPDM_MESSAGE_VERSION_13:
+                test_result = COMMON_TEST_RESULT_PASS;
+                break;
+            default:
+                test_result = COMMON_TEST_RESULT_FAIL;
+                break;
         }
         common_test_record_test_assertion (
             SPDM_RESPONDER_TEST_GROUP_VERSION, SPDM_RESPONDER_TEST_CASE_VERSION_SUCCESS_10, 5,


### PR DESCRIPTION
This updates test case 1 to check for and confirm report of SPDM 1.3 in GET_VERSION.

* Minor change to SPDM version check.
* Added check for SPDM 1.3
* Updated test documentation.