### PR TITLE
Fix Case 2.6: Non-identical GET_CAPABILITIES requests

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -1109,7 +1109,7 @@ void spdm_test_case_capabilities_unexpected_non_identical (void *test_context)
         spdm_response_size = sizeof(message);
         libspdm_zero_mem(message, sizeof(message));
         status = libspdm_send_receive_data(spdm_context, NULL, false,
-                                           &spdm_request, spdm_request_size,
+                                           &spdm_request_new, spdm_request_size,
                                            spdm_response, &spdm_response_size);
         if (LIBSPDM_STATUS_IS_ERROR(status)) {
             common_test_record_test_assertion (


### PR DESCRIPTION
Due to a typo, identical requests are being sent instead of non-identical in this case. Tests were still passing because responder from DMTF libspdm repository does not support retries, so both identical and non-identical requests were resulting in SPDM_ERROR (Unexpected Request).