### PR TITLE
Update Challenge Auth tests for SPDM 1.3

### DIFF
--- a/doc/6.ChallengeAuth.md
+++ b/doc/6.ChallengeAuth.md
@@ -296,14 +296,14 @@ Assertion 6.6.*.
 
 ### Case 6.7
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A1, B1, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A1, B1, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -352,7 +352,7 @@ Assertion 6.7.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.7.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 13. Repeat (1~12) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -364,14 +364,14 @@ Assertion 6.7.*.
 
 ### Case 6.8
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A1, B2, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A1, B2, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -416,7 +416,7 @@ Assertion 6.8.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.8.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 9. Repeat (1~8) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -428,14 +428,14 @@ Assertion 6.8.*.
 
 ### Case 6.9
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A1, B3, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A1, B3, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -482,7 +482,7 @@ Assertion 6.9.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.9.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 11. Repeat (1~10) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -494,14 +494,14 @@ Assertion 6.9.*.
 
 ### Case 6.10
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A1, B4, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A1, B4, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -548,7 +548,7 @@ Assertion 6.10.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.10.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 11. Repeat (1~10) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -560,14 +560,14 @@ Assertion 6.10.*.
 
 ### Case 6.11
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A2, B1, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A2, B1, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -612,7 +612,7 @@ Assertion 6.11.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.11.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 7. Repeat (1~6) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -624,14 +624,14 @@ Assertion 6.11.*.
 
 ### Case 6.12
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A2, B2, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A2, B2, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -672,7 +672,7 @@ Assertion 6.12.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.12.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 3. Repeat (1~2) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -684,14 +684,14 @@ Assertion 6.12.*.
 
 ### Case 6.13
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A2, B3, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A2, B3, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -734,7 +734,7 @@ Assertion 6.13.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.13.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 5. Repeat (1~4) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -746,14 +746,14 @@ Assertion 6.13.*.
 
 ### Case 6.14
 
-Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 in (A2, B4, C1).
+Description: SPDM responder shall return valid CHALLENGE_AUTH, if it receives a CHALLENGE with negotiated version 1.2 or 1.3 in (A2, B4, C1).
 
-SPDM Version: 1.2 only
+SPDM Version: 1.2, 1.3
 
 TestSetup:
 1. Requester -> GET_VERSION {SPDMVersion=0x10}
 2. VERSION <- Responder
-3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
+3. If 1.2 or 1.3 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
 6. If Flags.CERT_CAP == 0 || Flags.CHAL_CAP == 0, then skip this case.
@@ -796,7 +796,7 @@ Assertion 6.14.6:
     SpdmMessage.CertChainHash == Digests[SlotID]
 
 Assertion 6.14.7:
-    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 success.
+    SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
 
 5. Repeat (1~4) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 

--- a/doc/6.ChallengeAuth.md
+++ b/doc/6.ChallengeAuth.md
@@ -329,7 +329,7 @@ Steps:
 8. DIGESTS <- Responder
 9. Requester -> GET_CERTIFICATE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], ...}
 10. CERTIFICATE <- Responder
-11. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+11. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 12. SpdmMessage <- Responder
 
 Assertion 6.7.1:
@@ -353,6 +353,9 @@ Assertion 6.7.6:
 
 Assertion 6.7.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.7.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 13. Repeat (1~12) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -393,7 +396,7 @@ Steps:
 4. CAPABILITIES <- Responder
 5. Requester -> NEGOTIATE_ALGORITHMS {SPDMVersion=NegotiatedVersion, ...}
 6. ALGORITHMS <- Responder
-7. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+7. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 8. SpdmMessage <- Responder
 
 Assertion 6.8.1:
@@ -417,6 +420,9 @@ Assertion 6.8.6:
 
 Assertion 6.8.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.8.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 9. Repeat (1~8) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -459,7 +465,7 @@ Steps:
 6. ALGORITHMS <- Responder
 7. Requester -> GET_DIGESTS {SPDMVersion=NegotiatedVersion, ...}
 8. DIGESTS <- Responder
-9. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+9. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 10. SpdmMessage <- Responder
 
 Assertion 6.9.1:
@@ -483,6 +489,9 @@ Assertion 6.9.6:
 
 Assertion 6.9.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.9.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 11. Repeat (1~10) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -525,7 +534,7 @@ Steps:
 6. ALGORITHMS <- Responder
 7. Requester -> GET_CERTIFICATE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], ...}
 8. CERTIFICATE <- Responder
-9. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+9. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 10. SpdmMessage <- Responder
 
 Assertion 6.10.1:
@@ -549,6 +558,9 @@ Assertion 6.10.6:
 
 Assertion 6.10.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.10.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 11. Repeat (1~10) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -589,7 +601,7 @@ Steps:
 2. DIGESTS <- Responder
 3. Requester -> GET_CERTIFICATE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], ...}
 4. CERTIFICATE <- Responder
-5. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+5. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 6. SpdmMessage <- Responder
 
 Assertion 6.11.1:
@@ -613,6 +625,9 @@ Assertion 6.11.6:
 
 Assertion 6.11.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.11.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 7. Repeat (1~6) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -649,7 +664,7 @@ TestSetup:
 TestTeardown: None
 
 Steps:
-1. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+1. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 2. SpdmMessage <- Responder
 
 Assertion 6.12.1:
@@ -673,6 +688,9 @@ Assertion 6.12.6:
 
 Assertion 6.12.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.12.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 3. Repeat (1~2) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -711,7 +729,7 @@ TestTeardown: None
 Steps:
 1. Requester -> GET_DIGESTS {SPDMVersion=NegotiatedVersion, ...}
 2. DIGESTS <- Responder
-3. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+3. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 4. SpdmMessage <- Responder
 
 Assertion 6.13.1:
@@ -735,6 +753,9 @@ Assertion 6.13.6:
 
 Assertion 6.13.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.13.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 5. Repeat (1~4) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 
@@ -773,7 +794,7 @@ TestTeardown: None
 Steps:
 1. Requester -> GET_CERTIFICATE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], ...}
 2. CERTIFICATE <- Responder
-3. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce}
+3. Requester -> CHALLENGE {SPDMVersion=NegotiatedVersion, Param1.SlotID=ValidSlotID[i], Param2=NoMeasurement, Nonce, RequesterContext=RandomBytes}
 4. SpdmMessage <- Responder
 
 Assertion 6.14.1:
@@ -797,6 +818,9 @@ Assertion 6.14.6:
 
 Assertion 6.14.7:
     SPDMsignatureVerify (PubKey, SpdmMessage.Signature, M1/M2) version 1.2 or 1.3 success.
+
+Assertion 6.14.8
+    SpdmMessage.RequesterContext == RandomBytes version 1.3 success.
 
 5. Repeat (1~4) and use CHALLENGE {Param2=TcbMeasurements}, if Flags.MEAS_CAP != 0.
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -10,6 +10,24 @@
 #define SPDM_MESSAGE_B_MASK_GET_DIGESTS     0x2
 #define SPDM_MESSAGE_B_MASK_GET_CERTIFICATE 0x4
 
+#define SPDM_VERSION_ALL_COUNT 4
+static spdm_version_number_t spdm_version_all[SPDM_VERSION_ALL_COUNT] = {
+    SPDM_MESSAGE_VERSION_13 << SPDM_VERSION_NUMBER_SHIFT_BIT,
+    SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT,
+    SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT,
+    SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT,
+};
+
+#pragma pack(1)
+typedef struct {
+    spdm_message_header_t header;
+    /* param1 == slot_id
+     * param2 == HashType*/
+    uint8_t nonce[32];
+    uint8_t requester_context[SPDM_REQ_CONTEXT_SIZE];
+} spdm_challenge_request_13_t;
+#pragma pack()
+
 #pragma pack(1)
 typedef struct {
     uint8_t version;
@@ -53,6 +71,10 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
         parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
         libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
                          spdm_version, sizeof(spdm_version_number_t) * spdm_version_count);
+    } else {
+        parameter.location = LIBSPDM_DATA_LOCATION_LOCAL;
+        libspdm_set_data(spdm_context, LIBSPDM_DATA_SPDM_VERSION, &parameter,
+                         spdm_version_all, sizeof(spdm_version_number_t) * SPDM_VERSION_ALL_COUNT);
     }
 
     data32 = SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP |
@@ -189,7 +211,7 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
 
     spdm_test_context->test_scratch_buffer_size = offsetof(spdm_challenge_auth_test_buffer_t,
                                                            total_digest_buffer) +
-                                                  test_buffer->hash_size * test_buffer->slot_count;
+                                                           test_buffer->hash_size * test_buffer->slot_count;
 
     return true;
 }
@@ -203,21 +225,22 @@ bool spdm_test_case_challenge_auth_setup_version_10_11 (void *test_context)
 {
     spdm_version_number_t spdm_version[] = {
         SPDM_MESSAGE_VERSION_11 << SPDM_VERSION_NUMBER_SHIFT_BIT,
-            SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT
+        SPDM_MESSAGE_VERSION_10 << SPDM_VERSION_NUMBER_SHIFT_BIT,
     };
     return spdm_test_case_challenge_auth_setup_vca_digest (test_context,
                                                            LIBSPDM_ARRAY_SIZE(
-                                                               spdm_version), spdm_version);
+                                                           spdm_version), spdm_version);
 }
 
-bool spdm_test_case_challenge_auth_setup_version_12 (void *test_context)
+bool spdm_test_case_challenge_auth_setup_version_12_13 (void *test_context)
 {
     spdm_version_number_t spdm_version[] = {
-        SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT
+        SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT,
+        SPDM_MESSAGE_VERSION_13 << SPDM_VERSION_NUMBER_SHIFT_BIT,
     };
     return spdm_test_case_challenge_auth_setup_vca_digest (test_context,
                                                            LIBSPDM_ARRAY_SIZE(
-                                                               spdm_version), spdm_version);
+                                                           spdm_version), spdm_version);
 }
 
 void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t version,
@@ -227,8 +250,10 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
     void *spdm_context;
     libspdm_return_t status;
     spdm_challenge_request_t spdm_request;
+    spdm_challenge_request_13_t spdm_request_13;
     spdm_challenge_auth_response_t *spdm_response;
     uint8_t message[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t spdm_request_size;
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_challenge_auth_test_buffer_t *test_buffer;
@@ -275,32 +300,34 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
         }
         break;
     case SPDM_MESSAGE_VERSION_12:
-        LIBSPDM_ASSERT (test_buffer->version == SPDM_MESSAGE_VERSION_12);
+    case SPDM_MESSAGE_VERSION_13:
+        LIBSPDM_ASSERT ((test_buffer->version == SPDM_MESSAGE_VERSION_12) ||
+                        (test_buffer->version == SPDM_MESSAGE_VERSION_13));
         switch (message_mask) {
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_DIGESTS |
             SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B1C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B1C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B2C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B2C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_DIGESTS:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B3C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B3C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B4C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B4C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_DIGESTS | SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B1C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B1C1;
             break;
         case 0:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B2C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B2C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_DIGESTS:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B3C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B3C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B4C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B4C1;
             break;
         default:
             LIBSPDM_ASSERT(false);
@@ -374,19 +401,38 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                 }
             }
 
-            libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
-            spdm_request.header.spdm_version = test_buffer->version;
-            spdm_request.header.request_response_code = SPDM_CHALLENGE;
-            spdm_request.header.param1 = slot_id;
-            spdm_request.header.param2 = measurement_hash_type[meas_hash_type_index];
             /* ignore spdm_request.nonce */
+
+            if (test_buffer->version <= SPDM_MESSAGE_VERSION_12) {
+                libspdm_zero_mem(&spdm_request, sizeof(spdm_request));
+                spdm_request.header.spdm_version = test_buffer->version;
+                spdm_request.header.request_response_code = SPDM_CHALLENGE;
+                spdm_request.header.param1 = slot_id;
+                spdm_request.header.param2 = measurement_hash_type[meas_hash_type_index];
+                spdm_request_size = sizeof(spdm_request);
+            } else {
+                libspdm_zero_mem(&spdm_request, sizeof(spdm_request_13));
+                spdm_request_13.header.spdm_version = test_buffer->version;
+                spdm_request_13.header.request_response_code = SPDM_CHALLENGE;
+                spdm_request_13.header.param1 = slot_id;
+                spdm_request_13.header.param2 = measurement_hash_type[meas_hash_type_index];
+                spdm_request_size = sizeof(spdm_request) + SPDM_REQ_CONTEXT_SIZE;
+            }
 
             spdm_response = (void *)message;
             spdm_response_size = sizeof(message);
             libspdm_zero_mem(message, sizeof(message));
-            status = libspdm_send_receive_data(spdm_context, NULL, false,
-                                               &spdm_request, sizeof(spdm_request),
-                                               spdm_response, &spdm_response_size);
+            
+            if (test_buffer->version <= SPDM_MESSAGE_VERSION_12) {
+                status = libspdm_send_receive_data(spdm_context, NULL, false,
+                                                   &spdm_request, spdm_request_size,
+                                                   spdm_response, &spdm_response_size);
+            } else {
+                status = libspdm_send_receive_data(spdm_context, NULL, false,
+                                                   &spdm_request_13, spdm_request_size,
+                                                   spdm_response, &spdm_response_size);
+            }
+
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
                 common_test_record_test_assertion (
                     SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, 0,
@@ -432,6 +478,10 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                          test_buffer->hash_size + SPDM_NONCE_SIZE +
                          meas_hash_size + sizeof(uint16_t) +
                          *opaque_length_ptr);
+
+            if (test_buffer->version >= SPDM_MESSAGE_VERSION_13) {
+                signature_ptr += SPDM_REQ_CONTEXT_SIZE;
+            }
 
             if (spdm_response->header.request_response_code == SPDM_CHALLENGE_AUTH) {
                 test_result = COMMON_TEST_RESULT_PASS;
@@ -496,8 +546,14 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                 return;
             }
 
-            status = libspdm_append_message_c(spdm_context, &spdm_request,
-                                              sizeof(spdm_request));
+            if (test_buffer->version <= SPDM_MESSAGE_VERSION_12) {
+                status = libspdm_append_message_c(spdm_context, &spdm_request,
+                                                  spdm_request_size);
+            } else {
+                status = libspdm_append_message_c(spdm_context, &spdm_request_13,
+                                                  spdm_request_size);
+            }
+
             if (LIBSPDM_STATUS_IS_ERROR(status)) {
                 common_test_record_test_assertion (
                     SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, 0,
@@ -555,7 +611,7 @@ void spdm_test_case_challenge_auth_success_10_a1b3c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_a1b1c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a1b1c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -564,14 +620,14 @@ void spdm_test_case_challenge_auth_success_12_a1b1c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_a1b2c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a1b2c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
                                                  SPDM_MESSAGE_A_MASK_VCA);
 }
 
-void spdm_test_case_challenge_auth_success_12_a1b3c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a1b3c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -579,7 +635,7 @@ void spdm_test_case_challenge_auth_success_12_a1b3c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_a1b4c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a1b4c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -587,7 +643,7 @@ void spdm_test_case_challenge_auth_success_12_a1b4c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_a2b1c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a2b1c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -595,20 +651,20 @@ void spdm_test_case_challenge_auth_success_12_a2b1c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_a2b2c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a2b2c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12, 0);
 }
 
-void spdm_test_case_challenge_auth_success_12_a2b3c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a2b3c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_a2b4c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_13_a2b4c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -876,45 +932,45 @@ common_test_case_t m_spdm_test_group_challenge_auth[] = {
      spdm_test_case_challenge_auth_invalid_request,
      spdm_test_case_challenge_auth_setup_version_any,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B1C1,
-     "spdm_test_case_challenge_auth_success_12_a1b1c1",
-     spdm_test_case_challenge_auth_success_12_a1b1c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B1C1,
+     "spdm_test_case_challenge_auth_success_12_13_a1b1c1",
+     spdm_test_case_challenge_auth_success_12_13_a1b1c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B2C1,
-     "spdm_test_case_challenge_auth_success_12_a1b2c1",
-     spdm_test_case_challenge_auth_success_12_a1b2c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B2C1,
+     "spdm_test_case_challenge_auth_success_12_13_a1b2c1",
+     spdm_test_case_challenge_auth_success_12_13_a1b2c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B3C1,
-     "spdm_test_case_challenge_auth_success_12_a1b3c1",
-     spdm_test_case_challenge_auth_success_12_a1b3c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B3C1,
+     "spdm_test_case_challenge_auth_success_12_13_a1b3c1",
+     spdm_test_case_challenge_auth_success_12_13_a1b3c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B4C1,
-     "spdm_test_case_challenge_auth_success_12_a1b4c1",
-     spdm_test_case_challenge_auth_success_12_a1b4c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B4C1,
+     "spdm_test_case_challenge_auth_success_12_13_a1b4c1",
+     spdm_test_case_challenge_auth_success_12_13_a1b4c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B1C1,
-     "spdm_test_case_challenge_auth_success_12_a2b1c1",
-     spdm_test_case_challenge_auth_success_12_a2b1c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B1C1,
+     "spdm_test_case_challenge_auth_success_12_13_a2b1c1",
+     spdm_test_case_challenge_auth_success_12_13_a2b1c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B2C1,
-     "spdm_test_case_challenge_auth_success_12_a2b2c1",
-     spdm_test_case_challenge_auth_success_12_a2b2c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B2C1,
+     "spdm_test_case_challenge_auth_success_12_13_a2b2c1",
+     spdm_test_case_challenge_auth_success_12_13_a2b2c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B3C1,
-     "spdm_test_case_challenge_auth_success_12_a2b3c1",
-     spdm_test_case_challenge_auth_success_12_a2b3c1,
-     spdm_test_case_challenge_auth_setup_version_12,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B3C1,
+     "spdm_test_case_challenge_auth_success_12_13_a2b3c1",
+     spdm_test_case_challenge_auth_success_12_13_a2b3c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B4C1,
-     "spdm_test_case_challenge_auth_success_12_a2b4c1",
-     spdm_test_case_challenge_auth_success_12_a2b4c1,
-     spdm_test_case_challenge_auth_setup_version_12, 
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B4C1,
+     "spdm_test_case_challenge_auth_success_12_13_a2b4c1",
+     spdm_test_case_challenge_auth_success_12_13_a2b4c1,
+     spdm_test_case_challenge_auth_setup_version_12_13,
      spdm_test_case_common_teardown},
     {COMMON_TEST_ID_END, NULL, NULL},
 };

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -232,7 +232,7 @@ bool spdm_test_case_challenge_auth_setup_version_10_11 (void *test_context)
                                                            spdm_version), spdm_version);
 }
 
-bool spdm_test_case_challenge_auth_setup_version_12_13 (void *test_context)
+bool spdm_test_case_challenge_auth_setup_version_12 (void *test_context)
 {
     spdm_version_number_t spdm_version[] = {
         SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT,
@@ -306,28 +306,28 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
         switch (message_mask) {
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_DIGESTS |
             SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B1C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B1C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B2C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B2C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_DIGESTS:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B3C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B3C1;
             break;
         case SPDM_MESSAGE_A_MASK_VCA | SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B4C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B4C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_DIGESTS | SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B1C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B1C1;
             break;
         case 0:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B2C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B2C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_DIGESTS:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B3C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B3C1;
             break;
         case SPDM_MESSAGE_B_MASK_GET_CERTIFICATE:
-            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B4C1;
+            case_id = SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B4C1;
             break;
         default:
             LIBSPDM_ASSERT(false);
@@ -416,6 +416,7 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                 spdm_request_13.header.request_response_code = SPDM_CHALLENGE;
                 spdm_request_13.header.param1 = slot_id;
                 spdm_request_13.header.param2 = measurement_hash_type[meas_hash_type_index];
+                libspdm_get_random_number(SPDM_REQ_CONTEXT_SIZE, &spdm_request_13.requester_context[0]);
                 spdm_request_size = sizeof(spdm_request) + SPDM_REQ_CONTEXT_SIZE;
             }
 
@@ -480,6 +481,17 @@ void spdm_test_case_challenge_auth_success_10_12 (void *test_context, uint8_t ve
                          *opaque_length_ptr);
 
             if (test_buffer->version >= SPDM_MESSAGE_VERSION_13) {
+                uint8_t *requester_context = (uint8_t*)signature_ptr;
+
+                if (memcmp(requester_context, spdm_request_13.requester_context, SPDM_REQ_CONTEXT_SIZE) != 0) {
+                    test_result = COMMON_TEST_RESULT_FAIL;
+                } else {
+                    test_result = COMMON_TEST_RESULT_PASS;
+                }
+
+                common_test_record_test_assertion (SPDM_RESPONDER_TEST_GROUP_CHALLENGE_AUTH, case_id, 8,
+                test_result, "requester_context - %lx", &spdm_request_13.requester_context);
+
                 signature_ptr += SPDM_REQ_CONTEXT_SIZE;
             }
 
@@ -611,7 +623,7 @@ void spdm_test_case_challenge_auth_success_10_a1b3c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a1b1c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a1b1c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -620,14 +632,14 @@ void spdm_test_case_challenge_auth_success_12_13_a1b1c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a1b2c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a1b2c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
                                                  SPDM_MESSAGE_A_MASK_VCA);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a1b3c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a1b3c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -635,7 +647,7 @@ void spdm_test_case_challenge_auth_success_12_13_a1b3c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a1b4c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a1b4c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -643,7 +655,7 @@ void spdm_test_case_challenge_auth_success_12_13_a1b4c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a2b1c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a2b1c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -651,20 +663,20 @@ void spdm_test_case_challenge_auth_success_12_13_a2b1c1 (void *test_context)
                                                  SPDM_MESSAGE_B_MASK_GET_CERTIFICATE);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a2b2c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a2b2c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12, 0);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a2b3c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a2b3c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
                                                  SPDM_MESSAGE_B_MASK_GET_DIGESTS);
 }
 
-void spdm_test_case_challenge_auth_success_12_13_a2b4c1 (void *test_context)
+void spdm_test_case_challenge_auth_success_12_a2b4c1 (void *test_context)
 {
     spdm_test_case_challenge_auth_success_10_12 (test_context,
                                                  SPDM_MESSAGE_VERSION_12,
@@ -932,45 +944,45 @@ common_test_case_t m_spdm_test_group_challenge_auth[] = {
      spdm_test_case_challenge_auth_invalid_request,
      spdm_test_case_challenge_auth_setup_version_any,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B1C1,
-     "spdm_test_case_challenge_auth_success_12_13_a1b1c1",
-     spdm_test_case_challenge_auth_success_12_13_a1b1c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B1C1,
+     "spdm_test_case_challenge_auth_success_12_a1b1c1",
+     spdm_test_case_challenge_auth_success_12_a1b1c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B2C1,
-     "spdm_test_case_challenge_auth_success_12_13_a1b2c1",
-     spdm_test_case_challenge_auth_success_12_13_a1b2c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B2C1,
+     "spdm_test_case_challenge_auth_success_12_a1b2c1",
+     spdm_test_case_challenge_auth_success_12_a1b2c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B3C1,
-     "spdm_test_case_challenge_auth_success_12_13_a1b3c1",
-     spdm_test_case_challenge_auth_success_12_13_a1b3c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B3C1,
+     "spdm_test_case_challenge_auth_success_12_a1b3c1",
+     spdm_test_case_challenge_auth_success_12_a1b3c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A1B4C1,
-     "spdm_test_case_challenge_auth_success_12_13_a1b4c1",
-     spdm_test_case_challenge_auth_success_12_13_a1b4c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A1B4C1,
+     "spdm_test_case_challenge_auth_success_12_a1b4c1",
+     spdm_test_case_challenge_auth_success_12_a1b4c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B1C1,
-     "spdm_test_case_challenge_auth_success_12_13_a2b1c1",
-     spdm_test_case_challenge_auth_success_12_13_a2b1c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B1C1,
+     "spdm_test_case_challenge_auth_success_12_a2b1c1",
+     spdm_test_case_challenge_auth_success_12_a2b1c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B2C1,
-     "spdm_test_case_challenge_auth_success_12_13_a2b2c1",
-     spdm_test_case_challenge_auth_success_12_13_a2b2c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B2C1,
+     "spdm_test_case_challenge_auth_success_12_a2b2c1",
+     spdm_test_case_challenge_auth_success_12_a2b2c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B3C1,
-     "spdm_test_case_challenge_auth_success_12_13_a2b3c1",
-     spdm_test_case_challenge_auth_success_12_13_a2b3c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B3C1,
+     "spdm_test_case_challenge_auth_success_12_a2b3c1",
+     spdm_test_case_challenge_auth_success_12_a2b3c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
-    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_13_A2B4C1,
-     "spdm_test_case_challenge_auth_success_12_13_a2b4c1",
-     spdm_test_case_challenge_auth_success_12_13_a2b4c1,
-     spdm_test_case_challenge_auth_setup_version_12_13,
+    {SPDM_RESPONDER_TEST_CASE_CHALLENGE_AUTH_SUCCESS_12_A2B4C1,
+     "spdm_test_case_challenge_auth_success_12_a2b4c1",
+     spdm_test_case_challenge_auth_success_12_a2b4c1,
+     spdm_test_case_challenge_auth_setup_version_12,
      spdm_test_case_common_teardown},
     {COMMON_TEST_ID_END, NULL, NULL},
 };


### PR DESCRIPTION
This updates the Challenge Auth tests to accept SPDM 1.3 responders. The tests are shared with SPDM 1.2, with some minor changes to handle SPDM 1.3 updates to requests and responses (namely requester context data.)

This also fixes an issue where running an SPDM 1.x test after SPDM 1.0 tests would fail as the infrastructure clears out the local supported SPDM versions, resulting in a version negotiation failure.

* Added responder context bytes to request and response calculations
* Adjusted all SPDM 1.2 tests to be SPDM 1.2 and 1.3 tests.
  > Base test names 10_12_ were not altered
* Reset supported versions for "all" setups to resolve invalid version negotiation failures.
* Added an "all" list for SPDM version numbers.
* Added trailing commas for array initializers that may have more entries down the line.