### PR TITLE
Add CHUNK_CAP support in SPDM 1.2 for flexible size configuration

### DIFF
--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -174,6 +174,11 @@ Assertion 2.4.*.
 
 Assertion 2.4.*.
 
+11. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, Flags&=~CHUNK_CAP, DataTransferSize!=MaxSPDMmsgSize} -- if NegotiatedVersion=1.2+
+12. SpdmMessage <- Responder
+
+Assertion 2.4.*.
+
 ### Case 2.5
 
 Description: SPDM responder shall return valid CAPABILITIES(0x12), if it receives a GET_CAPABILITIES with negotiated version 1.2.

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -51,7 +51,8 @@ bool spdm_test_case_heartbeat_ack_setup_session (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -51,7 +51,8 @@ bool spdm_test_case_key_update_ack_setup_session (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_PSK_CAP_REQUESTER |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -51,7 +51,8 @@ bool spdm_test_case_end_session_ack_setup_session (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
@@ -61,7 +61,8 @@ bool spdm_test_case_algorithms_setup_version_capabilities (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
@@ -46,7 +46,8 @@ bool spdm_test_case_digests_setup_vca (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -50,7 +50,8 @@ bool spdm_test_case_certificate_setup_vca_digest (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -62,7 +62,8 @@ bool spdm_test_case_challenge_auth_setup_vca_digest (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -59,7 +59,8 @@ bool spdm_test_case_measurements_setup_vca_challenge_session (void *test_context
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -71,7 +71,8 @@ bool spdm_test_case_key_exchange_rsp_setup_vca_digest (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     if (hs_clear) {
         data32 |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     }
@@ -287,7 +288,8 @@ bool spdm_test_case_key_exchange_rsp_setup_version_capabilities (void *test_cont
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -60,7 +60,8 @@ bool spdm_test_case_finish_rsp_setup_vca_digest (void *test_context,
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     if (hs_clear) {
         data32 |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP;
     }
@@ -269,7 +270,8 @@ bool spdm_test_case_finish_rsp_setup_version_capabilities (void *test_context)
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_EX_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_ENCAP_CAP |
              SPDM_GET_CAPABILITIES_REQUEST_FLAGS_HBEAT_CAP |
-             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP;
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_KEY_UPD_CAP |
+             SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     libspdm_set_data(spdm_context, LIBSPDM_DATA_CAPABILITY_FLAGS, &parameter,
                      &data32, sizeof(data32));
 


### PR DESCRIPTION
Allow different MaxSPDMmsgSize and DataTransferSize by enabling CHUNK_CAP, where this change does not affect the test scenario

Fix: https://github.com/DMTF/SPDM-Responder-Validator/issues/162