### PR TITLE
Add a more check in case 2.4

### DIFF
--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -174,6 +174,11 @@ Assertion 2.4.*.
 
 Assertion 2.4.*.
 
+11. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, Flags&=~CHUNK_CAP, DataTransferSize!=MaxSPDMmsgSize} -- if NegotiatedVersion=1.2+
+12. SpdmMessage <- Responder
+
+Assertion 2.4.*.
+
 ### Case 2.5
 
 Description: SPDM responder shall return valid CAPABILITIES(0x12), if it receives a GET_CAPABILITIES with negotiated version 1.2.
@@ -231,7 +236,8 @@ Assertion 2.5.13:
     SpdmMessage.DataTransferSize >= MinDataTransferSize
 
 Assertion 2.5.14:
-    SpdmMessage.MaxSPDMmsgSize >= SpdmMessage.DataTransferSize
+    if (Flags.CHUNK_CAP == 1), then (SpdmMessage.MaxSPDMmsgSize >= SpdmMessage.DataTransferSize)
+    else if (Flags.CHUNK_CAP == 0), then (SpdmMessage.MaxSPDMmsgSize == SpdmMessage.DataTransferSize)
 
 Assertion 2.5.15:
     if (CHAL_CAP == 1 || MEAS_CAP == 2 || KEY_EX_CAP == 1) then (CERT_CAP == 1 || PUB_KEY_ID_CAP == 1)
@@ -336,7 +342,8 @@ Assertion 2.7.13:
     SpdmMessage.DataTransferSize >= MinDataTransferSize
 
 Assertion 2.7.14:
-    SpdmMessage.MaxSPDMmsgSize >= SpdmMessage.DataTransferSize
+    if (Flags.CHUNK_CAP == 1), then (SpdmMessage.MaxSPDMmsgSize >= SpdmMessage.DataTransferSize)
+    else if (Flags.CHUNK_CAP == 0), then (SpdmMessage.MaxSPDMmsgSize == SpdmMessage.DataTransferSize)
 
 Assertion 2.7.15:
     if (CHAL_CAP == 1 || MEAS_CAP == 2 || KEY_EX_CAP == 1) then (CERT_CAP == 1 || PUB_KEY_ID_CAP == 1)


### PR DESCRIPTION
- Check whether MaxSPDMmsgSize and DataTransferSize are the same or not when CHUNK_CAP is disable in v1.2

Fix: https://github.com/DMTF/SPDM-Responder-Validator/issues/162