### PR TITLE
clean mismatched_version definition to avoid confusion.

### DIFF
--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_12_heartbeat_ack.c
@@ -282,10 +282,7 @@ void spdm_test_case_heartbeat_ack_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_heartbeat_ack_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_13_key_update_ack.c
@@ -642,10 +642,7 @@ void spdm_test_case_key_update_ack_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_key_update_ack_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_16_end_session_ack.c
@@ -277,10 +277,7 @@ void spdm_test_case_end_session_ack_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_end_session_ack_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -254,10 +254,7 @@ void spdm_test_case_capabilities_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_capabilities_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_3_algorithms.c
@@ -366,10 +366,7 @@ void spdm_test_case_algorithms_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_algorithms_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_4_digests.c
@@ -271,10 +271,7 @@ void spdm_test_case_digests_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_digests_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -369,10 +369,7 @@ void spdm_test_case_certificate_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_certificate_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_6_challenge_auth.c
@@ -626,10 +626,7 @@ void spdm_test_case_challenge_auth_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_challenge_auth_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_7_measurements.c
@@ -1254,10 +1254,7 @@ void spdm_test_case_measurements_version_mismatch (void *test_context)
     size_t spdm_response_size;
     common_test_result_t test_result;
     spdm_measurements_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_8_key_exchange_rsp.c
@@ -701,10 +701,7 @@ void spdm_test_case_key_exchange_rsp_version_mismatch (void *test_context)
     bool result;
     common_test_result_t test_result;
     spdm_key_exchange_rsp_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_9_finish_rsp.c
@@ -515,10 +515,7 @@ void spdm_test_case_finish_rsp_version_mismatch (void *test_context)
     bool result;
     common_test_result_t test_result;
     spdm_finish_rsp_test_buffer_t *test_buffer;
-    uint8_t mismatched_version[] = {
-        SPDM_MESSAGE_VERSION_10 - 1,
-        SPDM_MESSAGE_VERSION_12 + 1,
-    };
+    uint8_t mismatched_version[2];
     size_t index;
 
     spdm_test_context = test_context;


### PR DESCRIPTION
The real value is assigned later.