### PR TITLE
doc: Fix KEY_UPDATE_ACK Case 13.5 capability gate

### DIFF
--- a/doc/13.KeyUpdateAck.md
+++ b/doc/13.KeyUpdateAck.md
@@ -258,7 +258,7 @@ TestSetup:
 3. If 1.2 is not in VERSION.VersionNumberEntry, then skip this case.
 4. Requester -> GET_CAPABILITIES {SPDMVersion=NegotiatedVersion, ...}
 5. CAPABILITIES <- Responder
-6. If Flags.HBEAT_CAP == 0, then skip this case.
+6. If Flags.KEY_UPD_CAP == 0, then skip this case.
 7. Requester -> NEGOTIATE_ALGORITHMS {SPDMVersion=NegotiatedVersion, ...}
 8. ALGORITHMS <- Responder
 


### PR DESCRIPTION
Gate on KEY_UPD_CAP instead of HBEAT_CAP, matching the other KEY_UPDATE cases.


Assisted-by: Claude Code:claude-opus-4-8