### PR TITLE
doc: Add SPDM 1.4 VERSION test coverage

### DIFF
--- a/doc/1.Version.md
+++ b/doc/1.Version.md
@@ -28,5 +28,5 @@ Assertion 1.1.4:
     SpdmMessage.VersionNumberEntryCount <= (sizeof(SpdmMessage) - offset(VERSION, VersionNumberEntry)) / sizeof(uint16_t)
 
 Assertion 1.1.5:
-    ((SpdmMessage.VersionNumberEntry[i].MajorVersion << 4) + SpdmMessage.VersionNumberEntry[i].MinorVersion) is in {0x10, 0x11, 0x12, 0x13}.
+    ((SpdmMessage.VersionNumberEntry[i].MajorVersion << 4) + SpdmMessage.VersionNumberEntry[i].MinorVersion) is in {0x10, 0x11, 0x12, 0x13, 0x14}.
 


### PR DESCRIPTION
Extend Assertion 1.1.5 version list to include 0x14.


Assisted-by: Claude Code:claude-opus-4-8

No code update since it added SPDM 1.4 before.