### PR TITLE
Add SPDM 1.4 CAPABILITIES test case

### DIFF
--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -356,3 +356,78 @@ Assertion 2.7.17:
 
 Assertion 2.7.18:
     if (Flags.MULTI_KEY_CAP != 0) then (Flags.GET_KEY_PAIR_INFO_CAP == 1)
+
+### Case 2.8
+
+Description: SPDM responder shall return valid CAPABILITIES(0x14), if it receives a GET_CAPABILITIES with negotiated version 1.4.
+
+SPDM Version: 1.4 only
+
+TestSetup: 
+1. Requester -> GET_VERSION {SPDMVersion=0x10}
+2. VERSION <- Responder
+3. If 1.4 is not in VERSION.VersionNumberEntry, then skip this case.
+
+TestTeardown: None
+
+Steps:
+1. Requester -> GET_CAPABILITIES {SPDMVersion=0x14, Param1=0, Param2=0, CTExponent, ExtFlags=0, Flags=CERT_CAP|CHAL_CAP|ENCRYPT_CAP|MAC_CAP|MUT_AUTH_CAP|KEY_EX_CAP|PSK_CAP=1|ENCAP_CAP|HBEAT_CAP|KEY_UPD_CAP|CHUNK_CAP|LARGE_RESP_CAP, DataTransferSize, MaxSPDMmsgSize}
+2. SpdmMessage <- Responder
+
+Assertion 2.8.1:
+    sizeof(SpdmMessage) >= sizeof(CAPABILITIES_1.4)
+
+Assertion 2.8.2:
+    SpdmMessage.RequestResponseCode == CAPABILITIES
+
+Assertion 2.8.3:
+    SpdmMessage.SPDMVersion == 0x14
+
+Assertion 2.8.4:
+    Flags.MEAS_CAP != 3
+
+Assertion 2.8.5:
+    if (Flags.ENCRYPT_CAP == 1), then (Flags.KEY_EX_CAP == 1 || Flags.PSK_CAP == 1 || Flags.PSK_CAP == 2)
+
+Assertion 2.8.6:
+    if (Flags.MAC_CAP == 1), then (Flags.KEY_EX_CAP == 1 || Flags.PSK_CAP == 1 || Flags.PSK_CAP == 2)
+
+Assertion 2.8.7:
+    if (Flags.KEY_EX_CAP == 1), then (Flags.ENCRYPT_CAP == 1 || Flags.MAC_CAP == 1)
+
+Assertion 2.8.8:
+    Flags.PSK_CAP != 3
+
+Assertion 2.8.9:
+    if (Flags.PSK_CAP != 0),  then (Flags.ENCRYPT_CAP == 1 || Flags.MAC_CAP == 1)
+
+Assertion 2.8.10:
+    if (Flags.MUT_AUTH_CAP == 1), then (Flags.ENCAP_CAP == 1)
+
+Assertion 2.8.11:
+    if (Flags.HANDSHAKE_IN_THE_CLEAR_CAP == 1), then (Flags.KEY_EX_CAP == 1)
+
+Assertion 2.8.12:
+    if (Flags.PUB_KEY_ID_CAP == 1), then (Flags.CERT_CAP == 0)
+
+Assertion 2.8.13:
+    SpdmMessage.DataTransferSize >= MinDataTransferSize
+
+Assertion 2.8.14:
+    if (Flags.CHUNK_CAP == 1), then (SpdmMessage.MaxSPDMmsgSize >= SpdmMessage.DataTransferSize)
+    else if (Flags.CHUNK_CAP == 0), then (SpdmMessage.MaxSPDMmsgSize == SpdmMessage.DataTransferSize)
+
+Assertion 2.8.15:
+    if (CHAL_CAP == 1 || MEAS_CAP == 2 || KEY_EX_CAP == 1) then (CERT_CAP == 1 || PUB_KEY_ID_CAP == 1)
+
+Assertion 2.8.16:
+    Flags.EP_INFO_CAP != 3
+
+Assertion 2.8.17:
+    Flags.MULTI_KEY_CAP != 3
+
+Assertion 2.8.18:
+    if (Flags.MULTI_KEY_CAP != 0) then (Flags.GET_KEY_PAIR_INFO_CAP == 1)
+
+Assertion 2.8.19:
+    if (Flags.SET_KEY_PAIR_RESET_CAP == 1), then (Flags.SET_KEY_PAIR_INFO_CAP == 1)

--- a/doc/2.Capabilities.md
+++ b/doc/2.Capabilities.md
@@ -346,4 +346,13 @@ Assertion 2.7.14:
     else if (Flags.CHUNK_CAP == 0), then (SpdmMessage.MaxSPDMmsgSize == SpdmMessage.DataTransferSize)
 
 Assertion 2.7.15:
-    if (CHAL_CAP == 1 || MEAS_CAP == 2 || KEY_EX_CAP == 1) then (CERT_CAP == 1 || PUB_KEY_ID_CAP == 1)
+    if (Flags.CHAL_CAP == 1 || Flags.MEAS_CAP == 2 || Flags.KEY_EX_CAP == 1) then (Flags.CERT_CAP == 1 || Flags.PUB_KEY_ID_CAP == 1)
+
+Assertion 2.7.16:
+    Flags.EP_INFO_CAP != 3
+
+Assertion 2.7.17:
+    Flags.MULTI_KEY_CAP != 3
+
+Assertion 2.7.18:
+    if (Flags.MULTI_KEY_CAP != 0) then (Flags.GET_KEY_PAIR_INFO_CAP == 1)

--- a/include/library/spdm_responder_conformance_test_lib.h
+++ b/include/library/spdm_responder_conformance_test_lib.h
@@ -26,6 +26,7 @@ void spdm_responder_conformance_test (void *spdm_context,
 #define   SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_12                        5
 #define   SPDM_RESPONDER_TEST_CASE_CAPABILITIES_UNEXPECTED_REQUEST_NON_IDENTICAL  6
 #define   SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_13                        7
+#define   SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_14                        8
 
 #define SPDM_RESPONDER_TEST_GROUP_ALGORITHMS    3
 #define   SPDM_RESPONDER_TEST_CASE_ALGORITHMS_SUCCESS_10                        1

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -1045,6 +1045,40 @@ void spdm_test_case_capabilities_success_12_13 (void *test_context, uint32_t spd
             test_version, 15,
             test_result, "response flags - 0x%08x", spdm_response->flags);
     }
+
+    if (message_version >= SPDM_MESSAGE_VERSION_13) {
+        if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_EP_INFO_CAP) !=
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_EP_INFO_CAP) {
+            test_result = COMMON_TEST_RESULT_PASS;
+        } else {
+            test_result = COMMON_TEST_RESULT_FAIL;
+        }
+        common_test_record_test_assertion (
+            SPDM_RESPONDER_TEST_GROUP_CAPABILITIES, test_version, 16,
+            test_result, "response flags - 0x%08x", spdm_response->flags);
+
+        if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP) !=
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP) {
+            test_result = COMMON_TEST_RESULT_PASS;
+        } else {
+            test_result = COMMON_TEST_RESULT_FAIL;
+        }
+        common_test_record_test_assertion (
+            SPDM_RESPONDER_TEST_GROUP_CAPABILITIES, test_version, 17,
+            test_result, "response flags - 0x%08x", spdm_response->flags);
+
+        if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MULTI_KEY_CAP) != 0) {
+            if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_GET_KEY_PAIR_INFO_CAP) != 0) {
+                test_result = COMMON_TEST_RESULT_PASS;
+            } else {
+                test_result = COMMON_TEST_RESULT_FAIL;
+            }
+            common_test_record_test_assertion (
+                SPDM_RESPONDER_TEST_GROUP_CAPABILITIES,
+                test_version, 18,
+                test_result, "response flags - 0x%08x", spdm_response->flags);
+        }
+    }
 }
 void spdm_test_case_capabilities_success_12 (void *test_context)
 {

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_2_capabilities.c
@@ -158,6 +158,13 @@ bool spdm_test_case_capabilities_setup_version_13 (void *test_context)
         SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
+bool spdm_test_case_capabilities_setup_version_14 (void *test_context)
+{
+    return spdm_test_case_capabilities_setup_version (test_context,
+                                                      SPDM_MESSAGE_VERSION_14 <<
+        SPDM_VERSION_NUMBER_SHIFT_BIT);
+}
+
 void spdm_test_case_capabilities_success_10 (void *test_context)
 {
     spdm_test_context_t *spdm_test_context;
@@ -791,7 +798,7 @@ void spdm_test_case_capabilities_invalid_request (void *test_context)
     }
 }
 
-void spdm_test_case_capabilities_success_12_13 (void *test_context, uint32_t spdm_version)
+void spdm_test_case_capabilities_success_12_13_14 (void *test_context, uint32_t spdm_version)
 {
     spdm_test_context_t *spdm_test_context;
     void *spdm_context;
@@ -809,14 +816,17 @@ void spdm_test_case_capabilities_success_12_13 (void *test_context, uint32_t spd
 
     switch (message_version) {
         case SPDM_MESSAGE_VERSION_12:
-             test_version = SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_12;
+            test_version = SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_12;
             break;
         case SPDM_MESSAGE_VERSION_13:
             test_version = SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_13;
             break;
+        case SPDM_MESSAGE_VERSION_14:
+            test_version = SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_14;
+            break;
         default:
             return;
-    }           
+    }
 
     spdm_test_context = test_context;
     spdm_context = spdm_test_context->spdm_context;
@@ -842,6 +852,9 @@ void spdm_test_case_capabilities_success_12_13 (void *test_context, uint32_t spd
                          SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHUNK_CAP;
     spdm_request.data_transfer_size = test_buffer->data_transfer_size;
     spdm_request.max_spdm_msg_size = test_buffer->max_spdm_msg_size;
+    if (message_version >= SPDM_MESSAGE_VERSION_14) {
+        spdm_request.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_LARGE_RESP_CAP;
+    }
 
     spdm_response = (void *)message;
     spdm_response_size = sizeof(message);
@@ -1079,13 +1092,27 @@ void spdm_test_case_capabilities_success_12_13 (void *test_context, uint32_t spd
                 test_result, "response flags - 0x%08x", spdm_response->flags);
         }
     }
+
+    if (message_version >= SPDM_MESSAGE_VERSION_14) {
+        if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_KEY_PAIR_RESET_CAP) != 0) {
+            if ((flags & SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_KEY_PAIR_INFO_CAP) != 0) {
+                test_result = COMMON_TEST_RESULT_PASS;
+            } else {
+                test_result = COMMON_TEST_RESULT_FAIL;
+            }
+            common_test_record_test_assertion (
+                SPDM_RESPONDER_TEST_GROUP_CAPABILITIES,
+                test_version, 19,
+                test_result, "response flags - 0x%08x", spdm_response->flags);
+        }
+    }
 }
+
 void spdm_test_case_capabilities_success_12 (void *test_context)
 {
-    spdm_test_case_capabilities_success_12_13(test_context, SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT);
+    spdm_test_case_capabilities_success_12_13_14(test_context, SPDM_MESSAGE_VERSION_12 << SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
     
-
 void spdm_test_case_capabilities_unexpected_non_identical (void *test_context)
 {
     spdm_test_context_t *spdm_test_context;
@@ -1275,7 +1302,12 @@ void spdm_test_case_capabilities_unexpected_non_identical (void *test_context)
 
 void spdm_test_case_capabilities_success_13 (void *test_context)
 {
-    spdm_test_case_capabilities_success_12_13(test_context, SPDM_MESSAGE_VERSION_13 << SPDM_VERSION_NUMBER_SHIFT_BIT);
+    spdm_test_case_capabilities_success_12_13_14(test_context, SPDM_MESSAGE_VERSION_13 << SPDM_VERSION_NUMBER_SHIFT_BIT);
+}
+
+void spdm_test_case_capabilities_success_14 (void *test_context)
+{
+    spdm_test_case_capabilities_success_12_13_14(test_context, SPDM_MESSAGE_VERSION_14 << SPDM_VERSION_NUMBER_SHIFT_BIT);
 }
 
 common_test_case_t m_spdm_test_group_capabilities[] = {
@@ -1313,6 +1345,11 @@ common_test_case_t m_spdm_test_group_capabilities[] = {
      "spdm_test_case_capabilities_success_13",
      spdm_test_case_capabilities_success_13,
      spdm_test_case_capabilities_setup_version_13,
+     spdm_test_case_common_teardown},
+    {SPDM_RESPONDER_TEST_CASE_CAPABILITIES_SUCCESS_14,
+     "spdm_test_case_capabilities_success_14",
+     spdm_test_case_capabilities_success_14,
+     spdm_test_case_capabilities_setup_version_14,
      spdm_test_case_common_teardown},
     {COMMON_TEST_ID_END, NULL, NULL},
 };


### PR DESCRIPTION
Add Case 2.8 for SPDM version 1.4, covering the SET_KEY_PAIR_RESET_CAP.


Assisted-by: Claude Code:claude-opus-4-8