### PR TITLE
Use >= for size check due to transport padding

### DIFF
--- a/doc/5.Certificate.md
+++ b/doc/5.Certificate.md
@@ -241,7 +241,7 @@ Steps:
 2. SpdmMessage <- Responder
 
 Assertion 5.6.1:
-    sizeof(SpdmMessage) == sizeof(CERTIFICATE, CertChain)
+    sizeof(SpdmMessage) >= sizeof(CERTIFICATE, CertChain)
 
 Assertion 5.6.2:
     SpdmMessage.RequestResponseCode == CERTIFICATE

--- a/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
+++ b/library/spdm_responder_conformance_test_lib/spdm_responder_test_5_certificate.c
@@ -639,7 +639,7 @@ void spdm_test_case_certificate_size_req(void *test_context)
             return;
         }
 
-        if (spdm_response_size == sizeof(spdm_certificate_response_t)) {
+        if (spdm_response_size >= sizeof(spdm_certificate_response_t)) {
             test_result = COMMON_TEST_RESULT_PASS;
         } else {
             test_result = COMMON_TEST_RESULT_FAIL;


### PR DESCRIPTION
Fix https://github.com/DMTF/SPDM-Responder-Validator/issues/192